### PR TITLE
Changed default port before making it configurable

### DIFF
--- a/aws/alb.go
+++ b/aws/alb.go
@@ -176,7 +176,7 @@ func normalizeLoadBalancerName(name string) string {
 func createDefaultTargetGroup(alb elbv2iface.ELBV2API, name string, vpcID string) (string, error) {
 	params := &elbv2.CreateTargetGroupInput{
 		HealthCheckPath: aws.String("/healthz"),
-		Port:            aws.Int64(9090),
+		Port:            aws.Int64(9999),
 		Protocol:        aws.String(elbv2.ProtocolEnumHttp),
 		VpcId:           aws.String(vpcID),
 		Name:            aws.String(name),


### PR DESCRIPTION
We should refactor the code to make it possible to configure the port. This require some changes in the way the options are read. For the moment, we just pick a different port for the sake of testing. 