### PR TITLE
Fix deleting LB managed by controller

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -242,20 +242,16 @@ func (a *Adapter) DeleteLoadBalancer(loadBalancer *LoadBalancer) error {
 		if err := deleteListener(a.elbv2, loadBalancer.listeners.https.arn); err != nil {
 			return err
 		}
-
-		if err := detachTargetGroupFromAutoScalingGroup(a.autoscaling, targetGroupARN, a.manifest.autoScalingGroup.name); err != nil {
-			return err
-		}
 	}
 
 	if loadBalancer.listeners.http != nil {
 		if err := deleteListener(a.elbv2, loadBalancer.listeners.http.arn); err != nil {
 			return err
 		}
+	}
 
-		if err := detachTargetGroupFromAutoScalingGroup(a.autoscaling, targetGroupARN, a.manifest.autoScalingGroup.name); err != nil {
-			return err
-		}
+	if err := detachTargetGroupFromAutoScalingGroup(a.autoscaling, targetGroupARN, a.manifest.autoScalingGroup.name); err != nil {
+		return err
 	}
 
 	if err := deleteTargetGroup(a.elbv2, targetGroupARN); err != nil {


### PR DESCRIPTION
#28 introduced two bugs related to deleting an ALB managed by the
controller. First bug was attempting to detach the target group from the
ASG twice. Second bug was not initializing the http listener struct when
getting an ALB, this meant the http listener was never deleted from the
ALB and thus the ALB deletion failed because of the active listener
resource.

This fixes both of those issues.

@lmineiro thanks for the heads up! Please take a look.

I'm fine with merging #26 first and then add the related tests to this PR.