### PR TITLE
Fail fast if DescribeListeners returns error

### DIFF
--- a/aws/alb.go
+++ b/aws/alb.go
@@ -294,7 +294,7 @@ func findManagedLoadBalancers(svc elbv2iface.ELBV2API, clusterID string) ([]*Loa
 				listeners, err := getListeners(svc, loadBalancerARN)
 				if err != nil {
 					log.Printf("failed to describe listeners for load balancer ARN %q: %v\n", loadBalancerARN, err)
-					continue
+					return nil, err
 				}
 
 				listener, certARN := findFirstListenerWithAnyCertificate(listeners)

--- a/aws/alb_test.go
+++ b/aws/alb_test.go
@@ -231,7 +231,7 @@ func TestFindingManagedLoadBalancers(t *testing.T) {
 			},
 			"fake-cluster-id", "",
 			nil,
-			false,
+			true,
 		},
 		{
 			"no-matching-listeners",


### PR DESCRIPTION
If we get rate limited in the call to DescribeLoadBalancer we could end up with a wrong list of ALBs, which would trigger an ALB create.