### PR TITLE
Collect metrics about issued API requests

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/linki/instrumented_http"
 )
 
 // An Adapter can be used to orchestrate and obtain information from Amazon Web Services.
@@ -72,7 +73,9 @@ var (
 var configProvider = defaultConfigProvider
 
 func defaultConfigProvider() client.ConfigProvider {
-	return session.Must(session.NewSession(aws.NewConfig().WithMaxRetries(3)))
+	config := aws.NewConfig().WithMaxRetries(3)
+	config = config.WithHTTPClient(instrumented_http.NewClient(config.HTTPClient, nil))
+	return session.Must(session.NewSession(config))
 }
 
 // NewAdapter returns a new Adapter that can be used to orchestrate and obtain information from Amazon Web Services.

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-hash: c5d0ee7122d41a94629ca3c25d197a0e3385071bfbd6f11fb9b194fec789606d
-updated: 2017-05-16T14:17:59.877172145+02:00
+hash: e806b9ddcb22df8bfc480ef90f003a79f22a80e315bf93d07a02dac083ada602
+updated: 2017-05-16T16:22:12.723854051+02:00
 imports:
+- name: bitbucket.org/ww/goautoneg
+  version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: github.com/aws/aws-sdk-go
   version: 9f8b24cb7c7701c78150869d906711a2e7184bc0
   subpackages:
@@ -39,12 +41,42 @@ imports:
   - service/iam
   - service/iam/iamiface
   - service/sts
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/go-ini/ini
   version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
+- name: github.com/golang/protobuf
+  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
+  subpackages:
+  - proto
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/linki/instrumented_http
+  version: 74fdeadb7e945ec3cc9dcbefed6a6b148ef00d18
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  subpackages:
+  - pbutil
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
+  subpackages:
+  - expfmt
+  - model
+- name: github.com/prometheus/procfs
+  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
 testImports:
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,6 +19,8 @@ import:
   - service/iam/iamiface
 - package: github.com/pkg/errors
   version: ~0.8.0
+- package: github.com/linki/instrumented_http
+  version: ~0.1.0
 testImport:
 - package: github.com/davecgh/go-spew
   version: ~1.1.0

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -9,7 +9,10 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"time"
+
+	"github.com/linki/instrumented_http"
 )
 
 type client interface {
@@ -61,6 +64,13 @@ func newSimpleClient(cfg *Config) (client, error) {
 			c.Timeout = cfg.Timeout
 		}
 	}
+
+	c = instrumented_http.NewClient(c, &instrumented_http.Callbacks{
+		PathProcessor: func(path string) string {
+			parts := strings.Split(path, "/")
+			return parts[len(parts)-1]
+		},
+	})
 
 	return &simpleClient{cfg: cfg, httpClient: c}, nil
 }


### PR DESCRIPTION
Just an idea how we can see how many requests to AWS and Kubernetes API we make.

Gives you something like this

```
http_request_duration_microseconds{handler="instrumented_http",host="10.3.0.1:443",method="GET",path="ingresses",query="",scheme="https",status="200",quantile="0.5"} 66904
http_request_duration_microseconds{handler="instrumented_http",host="10.3.0.1:443",method="GET",path="ingresses",query="",scheme="https",status="200",quantile="0.9"} 174219
http_request_duration_microseconds{handler="instrumented_http",host="10.3.0.1:443",method="GET",path="ingresses",query="",scheme="https",status="200",quantile="0.99"} 508884
http_request_duration_microseconds_sum{handler="instrumented_http",host="10.3.0.1:443",method="GET",path="ingresses",query="",scheme="https",status="200"} 1.510416e+06
http_request_duration_microseconds_count{handler="instrumented_http",host="10.3.0.1:443",method="GET",path="ingresses",query="",scheme="https",status="200"} 14
http_request_duration_microseconds{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="200",quantile="0.5"} 481655
http_request_duration_microseconds{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="200",quantile="0.9"} 1.300036e+06
http_request_duration_microseconds{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="200",quantile="0.99"} 1.300036e+06
http_request_duration_microseconds_sum{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="200"} 1.837559e+06
http_request_duration_microseconds_count{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="200"} 3
http_request_duration_microseconds{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="301",quantile="0.5"} 1337
http_request_duration_microseconds{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="301",quantile="0.9"} 1337
http_request_duration_microseconds{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="301",quantile="0.99"} 1337
http_request_duration_microseconds_sum{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="301"} 1337
http_request_duration_microseconds_count{handler="instrumented_http",host="169.254.169.254",method="GET",path="",query="",scheme="http",status="301"} 1
http_request_duration_microseconds{handler="instrumented_http",host="acm.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.5"} 77263
http_request_duration_microseconds{handler="instrumented_http",host="acm.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.9"} 88327
http_request_duration_microseconds{handler="instrumented_http",host="acm.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.99"} 88327
http_request_duration_microseconds_sum{handler="instrumented_http",host="acm.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 350058
http_request_duration_microseconds_count{handler="instrumented_http",host="acm.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 5
http_request_duration_microseconds{handler="instrumented_http",host="autoscaling.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.5"} 63402
http_request_duration_microseconds{handler="instrumented_http",host="autoscaling.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.9"} 63402
http_request_duration_microseconds{handler="instrumented_http",host="autoscaling.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.99"} 63402
http_request_duration_microseconds_sum{handler="instrumented_http",host="autoscaling.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 63402
http_request_duration_microseconds_count{handler="instrumented_http",host="autoscaling.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 1
http_request_duration_microseconds{handler="instrumented_http",host="ec2.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.5"} 70870
http_request_duration_microseconds{handler="instrumented_http",host="ec2.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.9"} 455170
http_request_duration_microseconds{handler="instrumented_http",host="ec2.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.99"} 455170
http_request_duration_microseconds_sum{handler="instrumented_http",host="ec2.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 990311
http_request_duration_microseconds_count{handler="instrumented_http",host="ec2.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 4
http_request_duration_microseconds{handler="instrumented_http",host="elasticloadbalancing.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.5"} 22471
http_request_duration_microseconds{handler="instrumented_http",host="elasticloadbalancing.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.9"} 42610
http_request_duration_microseconds{handler="instrumented_http",host="elasticloadbalancing.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.99"} 130153
http_request_duration_microseconds_sum{handler="instrumented_http",host="elasticloadbalancing.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 1.1262961e+07
http_request_duration_microseconds_count{handler="instrumented_http",host="elasticloadbalancing.eu-central-1.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 420
http_request_duration_microseconds{handler="instrumented_http",host="iam.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.5"} 114638
http_request_duration_microseconds{handler="instrumented_http",host="iam.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.9"} 388132
http_request_duration_microseconds{handler="instrumented_http",host="iam.amazonaws.com",method="POST",path="",query="",scheme="https",status="200",quantile="0.99"} 388132
http_request_duration_microseconds_sum{handler="instrumented_http",host="iam.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 732054
http_request_duration_microseconds_count{handler="instrumented_http",host="iam.amazonaws.com",method="POST",path="",query="",scheme="https",status="200"} 4
```