### PR TITLE
updated dependencies of the project

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: e806b9ddcb22df8bfc480ef90f003a79f22a80e315bf93d07a02dac083ada602
-updated: 2017-05-16T16:22:12.723854051+02:00
+hash: 86ed922a0d8ebedd825733b480d2f87f0a404f915e76b365640405e8fa51a719
+updated: 2017-05-31T10:28:32.181038829+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: github.com/aws/aws-sdk-go
-  version: 9f8b24cb7c7701c78150869d906711a2e7184bc0
+  version: a479673916dcc0f62674f085bb4112272b8d8560
   subpackages:
   - aws
   - aws/awserr
@@ -34,10 +34,11 @@ imports:
   - service/acm/acmiface
   - service/autoscaling
   - service/autoscaling/autoscalingiface
+  - service/cloudformation
+  - service/cloudformation/cloudformationiface
   - service/ec2
   - service/ec2/ec2iface
   - service/elbv2
-  - service/elbv2/elbv2iface
   - service/iam
   - service/iam/iamiface
   - service/sts
@@ -54,7 +55,7 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/linki/instrumented_http
-  version: 74fdeadb7e945ec3cc9dcbefed6a6b148ef00d18
+  version: 508103cfb3b315fa9752b5bcd4fb2d97bbc26d89
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
@@ -77,8 +78,4 @@ imports:
   - model
 - name: github.com/prometheus/procfs
   version: 454a56f35412459b5e684fd5ec0f9211b94f002a
-testImports:
-- name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
-  subpackages:
-  - spew
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,9 +1,10 @@
 package: github.com/zalando-incubator/kube-ingress-aws-controller
 import:
 - package: github.com/aws/aws-sdk-go
-  version: ~1.8.23
+  version: ~1.8.31
   subpackages:
   - aws
+  - aws/awserr
   - aws/client
   - aws/ec2metadata
   - aws/session
@@ -11,18 +12,18 @@ import:
   - service/acm/acmiface
   - service/autoscaling
   - service/autoscaling/autoscalingiface
+  - service/cloudformation
+  - service/cloudformation/cloudformationiface
   - service/ec2
   - service/ec2/ec2iface
   - service/elbv2
-  - service/elbv2/elbv2iface
   - service/iam
   - service/iam/iamiface
+- package: github.com/linki/instrumented_http
+  version: ~0.2.0
 - package: github.com/pkg/errors
   version: ~0.8.0
-- package: github.com/linki/instrumented_http
-  version: ~0.1.0
-testImport:
-- package: github.com/davecgh/go-spew
-  version: ~1.1.0
+- package: github.com/prometheus/client_golang
+  version: ~0.8.0
   subpackages:
-  - spew
+  - prometheus/promhttp


### PR DESCRIPTION
This updates the dependencies of the project, in particular: 

- update AWS SDK to latest version - this deserves testing 
- updates https://github.com/linki/instrumented_http to latest, the version previously used had poor error handling, (see https://github.com/linki/instrumented_http/blob/v0.1.0/client.go#L63) 
- removes unneeded dependency on spew (not used in tests anymore) 

