### PR TITLE
build image using multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN go get github.com/Masterminds/glide
 WORKDIR /go/src/github.com/zalando-incubator/kube-ingress-aws-controller
 COPY . .
 RUN glide install --strip-vendor
+RUN make test
 RUN make build.linux
 
 # final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM registry.opensource.zalan.do/stups/alpine:UPSTREAM
+# builder image
+FROM golang:1.8 as builder
+
+RUN go get github.com/Masterminds/glide
+WORKDIR /go/src/github.com/zalando-incubator/kube-ingress-aws-controller
+COPY . .
+RUN glide install --strip-vendor
+RUN make build.linux
+
+# final image
+FROM registry.opensource.zalan.do/stups/alpine:latest
 MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
 
-# add scm-source
-ADD scm-source.json /
+COPY --from=builder /go/src/github.com/zalando-incubator/kube-ingress-aws-controller/build/linux/kube-ingress-aws-controller \
+  /bin/kube-ingress-aws-controller
 
-# add binary
-ADD build/linux/kube-aws-ingress-controller /
-
-ENTRYPOINT ["/kube-aws-ingress-controller"]
+ENTRYPOINT ["/bin/kube-ingress-aws-controller"]

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ registry of your choice.
 To deploy the ingress controller, use the [example YAML](deploy/ingress-controller.yaml) as the descriptor. You can
 customize the image used in the example YAML file.
 
-We provide `registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:latest` as a publicly usable Docker image
+We provide `registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:latest` as a publicly usable Docker image
 built from this codebase. You can deploy it with 2 easy steps:
 - Replace the placeholder for your region inside the example YAML, for ex., `eu-west-1`
 - Use kubectl to execute the command  `kubectl apply -f deploy/ingress-controller.yaml`

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,28 +1,18 @@
 build_steps:
-    - desc: 'Install required build software'
-      cmd: |
-        apt-get update
-        apt-get install -y make git apt-transport-https ca-certificates \
-        curl software-properties-common python-software-properties
-    - desc: 'Install go'
-      cmd: |
-        add-apt-repository -y ppa:longsleep/golang-backports
-        apt-get update
-        apt-get install -y golang-go
-    - desc: 'Install Docker'
-      cmd: |
-        curl -sSL https://get.docker.com/ | sh
-    - desc: 'Symlink sources into the GOPATH'
-      cmd: |
-        export GOPATH=$HOME/go
-        export PKG_BASE_PATH=$GOPATH/src/github.com/zalando-incubator
-        mkdir -p $PKG_BASE_PATH
-        ln -s $(pwd) $PKG_BASE_PATH/kube-ingress-aws-controller
-    - desc: 'Build & push docker image'
-      cmd: |
-        export PATH=$PATH:$HOME/go/bin
-        IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
-        if [[ ${CDP_TARGET_BRANCH} == "master" && ${IS_PR_BUILD} != "true" ]]
-        then
-          make build.push
-        fi
+- desc: Install docker
+  cmd: |
+    apt-get update
+    apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+    apt-get update
+    apt-get install -y docker-ce
+- desc: Build and push docker image
+  cmd: |
+    image=registry-write.opensource.zalan.do/teapot/kube-ingress-aws-controller:${CDP_BUILD_VERSION}
+    docker build --tag $image .
+    IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
+    if [[ ${CDP_TARGET_BRANCH} == "master" && ${IS_PR_BUILD} != "true" ]]
+    then
+      docker push $image
+    fi

--- a/deploy/ingress-controller.yaml
+++ b/deploy/ingress-controller.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:latest
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:latest
         env:
         - name: AWS_REGION
           value: $YOUR_REGION


### PR DESCRIPTION
This uses Docker's new multi-stage dockerfiles to build.

It builds the binary inside a Docker containe and avoids cluttering the host machine with stuff. By using the new build stages this can conveniently be run with a simple `docekr build`.

unrelated: I consistently change any reference to the project to `kube-ingress-aws-controller`.