### PR TITLE
safely delete stack

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -266,11 +266,7 @@ func (a *Adapter) GetStack(stackID string) (*Stack, error) {
 func (a *Adapter) MarkToDeleteStack(stack *Stack) (time.Time, error) {
 	t0 := time.Now().Add(a.stackTTL)
 
-	if err := markToDeleteStack(a.cloudformation, a.stackName(stack.CertificateARN()), t0.Format(time.RFC3339)); err != nil {
-		return t0, fmt.Errorf("MarkToDeleteStack failed: %v", err)
-	}
-
-	return t0, nil
+	return t0, markToDeleteStack(a.cloudformation, a.stackName(stack.CertificateARN()), t0.Format(time.RFC3339))
 }
 
 // DeleteStack deletes the CloudFormation stack with the given name

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -42,6 +42,7 @@ type Adapter struct {
 	healthCheckPort     uint
 	healthCheckInterval time.Duration
 	creationTimeout     time.Duration
+	stackTTL            time.Duration
 }
 
 type manifest struct {
@@ -60,6 +61,7 @@ const (
 	DefaultHealthCheckInterval       = 10 * time.Second
 	DefaultCertificateUpdateInterval = 30 * time.Minute
 	DefaultCreationTimeout           = 5 * time.Minute
+	DefaultStackTTL                  = 5 * time.Minute
 
 	clusterIDTag = "ClusterID"
 	nameTag      = "Name"
@@ -119,6 +121,7 @@ func NewAdapter() (adapter *Adapter, err error) {
 		healthCheckPort:     DefaultHealthCheckPort,
 		healthCheckInterval: DefaultHealthCheckInterval,
 		creationTimeout:     DefaultCreationTimeout,
+		stackTTL:            DefaultStackTTL,
 	}
 
 	adapter.manifest, err = buildManifest(adapter)
@@ -261,7 +264,7 @@ func (a *Adapter) GetStack(stackID string) (*Stack, error) {
 
 // MarkToDeleteStack adds a "deleteScheduled" Tag to the CloudFormation stack with the given name
 func (a *Adapter) MarkToDeleteStack(stack *Stack) (time.Time, error) {
-	t0 := time.Now().Add(1 * time.Hour)
+	t0 := time.Now().Add(a.stackTTL)
 
 	if err := markToDeleteStack(a.cloudformation, a.stackName(stack.CertificateARN()), t0.Format(time.RFC3339)); err != nil {
 		return t0, fmt.Errorf("MarkToDeleteStack failed: %v", err)

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -3,11 +3,11 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
@@ -77,7 +77,7 @@ func (s *Stack) deleteTime() *time.Time {
 	}
 	t, err := time.Parse(time.RFC3339, ts)
 	if err != nil {
-		log.Errorf("Failed to parse time: %v", err)
+		log.Printf("Failed to parse time: %v", err)
 		return nil
 	}
 	return &t

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -206,6 +206,7 @@ func markToDeleteStack(svc cloudformationiface.CloudFormationAPI, stackName, ts 
 	params := &cloudformation.UpdateStackInput{
 		StackName:           aws.String(stackName),
 		Tags:                tags,
+		Parameters:          stack.Parameters,
 		UsePreviousTemplate: aws.Bool(true),
 	}
 

--- a/aws/cf_test.go
+++ b/aws/cf_test.go
@@ -407,8 +407,8 @@ func TestDeleteTime(t *testing.T) {
 		t.Run(ti.msg, func(t *testing.T) {
 			got := ti.given.deleteTime()
 			if ti.want != nil {
-				if *ti.want != *got {
-					t.Errorf("unexpected result for %s. wanted %+v, got %+v", ti.msg, ti.want, got)
+				if !ti.want.Equal(*got) {
+					t.Errorf("unexpected result for non nil %s. wanted %+v, got %+v", ti.msg, ti.want, got)
 				}
 			} else if ti.want != got {
 				t.Errorf("unexpected result for %s. wanted %+v, got %+v", ti.msg, ti.want, got)

--- a/aws/cf_test.go
+++ b/aws/cf_test.go
@@ -211,6 +211,11 @@ func TestFindingManagedStacks(t *testing.T) {
 					dnsName:        "example.com",
 					certificateARN: "cert-arn",
 					targetGroupARN: "tg-arn",
+					tags: map[string]string{
+						kubernetesCreatorTag: kubernetesCreatorValue,
+						clusterIDTag:         "test-cluster",
+						certificateARNTag:    "cert-arn",
+					},
 				},
 			},
 			false,

--- a/aws/cfmock_test.go
+++ b/aws/cfmock_test.go
@@ -10,6 +10,7 @@ type cfMockOutputs struct {
 	describeStackPages *apiResponse
 	describeStacks     *apiResponse
 	createStack        *apiResponse
+	deleteStack        *apiResponse
 }
 
 type mockCloudFormationClient struct {
@@ -53,4 +54,15 @@ func mockCSOutput(stackId string) *cloudformation.CreateStackOutput {
 	return &cloudformation.CreateStackOutput{
 		StackId: aws.String(stackId),
 	}
+}
+
+func (m *mockCloudFormationClient) DeleteStack(params *cloudformation.DeleteStackInput) (*cloudformation.DeleteStackOutput, error) {
+	if out, ok := m.outputs.deleteStack.response.(*cloudformation.DeleteStackOutput); ok {
+		return out, m.outputs.deleteStack.err
+	}
+	return nil, m.outputs.deleteStack.err
+}
+
+func mockDeleteStackOutput(stackId string) *cloudformation.DeleteStackOutput {
+	return &cloudformation.DeleteStackOutput{}
 }


### PR DESCRIPTION
fix for #68 : implement deleteScheduled tag to postpone deletion of ALBs 1 hour after trigger

to be discussed with @njuettner 