### PR TITLE
Build image on PR and use RELEASE_VERSION for master pushes

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -9,10 +9,13 @@ build_steps:
     apt-get install -y docker-ce
 - desc: Build and push docker image
   cmd: |
-    image=registry-write.opensource.zalan.do/teapot/kube-ingress-aws-controller:${CDP_BUILD_VERSION}
-    docker build --tag $image .
     IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
     if [[ ${CDP_TARGET_BRANCH} == "master" && ${IS_PR_BUILD} != "true" ]]
     then
-      docker push $image
+      RELEASE_VERSION=$(git describe --tags --always --dirty)
+      image=registry-write.opensource.zalan.do/teapot/kube-ingress-aws-controller:${RELEASE_VERSION}
+    else
+      image=registry-write.opensource.zalan.do/teapot/kube-ingress-aws-controller-test:${CDP_BUILD_VERSION}
     fi
+    docker build --tag $image .
+    docker push $image


### PR DESCRIPTION
This configures the delivery.yaml to build build and push images also for PRs. Images build from PRs will have a `-test` suffix so they don't clash with images produced from `master`.

It also changes the tag used for images build on master to use the `RELEASE_VERSION` (commit hash or tag) instead of `CDP_BUILD_VERSION`.