### PR TITLE
update-stack on ready CFs

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -253,6 +253,26 @@ func (a *Adapter) CreateStack(certificateARN string) (string, error) {
 	return createStack(a.cloudformation, spec)
 }
 
+func (a *Adapter) UpdateStack(certificateARN string) (string, error) {
+	spec := &createStackSpec{
+		name:            a.stackName(certificateARN),
+		scheme:          elbv2.LoadBalancerSchemeEnumInternetFacing,
+		certificateARN:  certificateARN,
+		securityGroupID: a.SecurityGroupID(),
+		subnets:         a.PublicSubnetIDs(),
+		vpcID:           a.VpcID(),
+		clusterID:       a.ClusterID(),
+		healthCheck: &healthCheck{
+			path:     a.healthCheckPath,
+			port:     a.healthCheckPort,
+			interval: a.healthCheckInterval,
+		},
+		timeoutInMinutes: uint(a.creationTimeout.Minutes()),
+	}
+
+	return updateStack(a.cloudformation, spec)
+}
+
 func (a *Adapter) stackName(certificateARN string) string {
 	return normalizeStackName(a.ClusterID(), certificateARN)
 }

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -234,7 +234,7 @@ func (a *Adapter) FindManagedStacks() ([]*Stack, error) {
 // All the required resources (listeners and target group) are created in a transactional fashion.
 // Failure to create the stack causes it to be deleted automatically.
 func (a *Adapter) CreateStack(certificateARN string) (string, error) {
-	spec := &createStackSpec{
+	spec := &stackSpec{
 		name:            a.stackName(certificateARN),
 		scheme:          elbv2.LoadBalancerSchemeEnumInternetFacing,
 		certificateARN:  certificateARN,
@@ -254,7 +254,7 @@ func (a *Adapter) CreateStack(certificateARN string) (string, error) {
 }
 
 func (a *Adapter) UpdateStack(certificateARN string) (string, error) {
-	spec := &createStackSpec{
+	spec := &stackSpec{
 		name:            a.stackName(certificateARN),
 		scheme:          elbv2.LoadBalancerSchemeEnumInternetFacing,
 		certificateARN:  certificateARN,

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -116,7 +116,7 @@ const (
 	parameterListenerCertificateParameter            = "ListenerCertificateParameter"
 )
 
-type createStackSpec struct {
+type stackSpec struct {
 	name             string
 	scheme           string
 	subnets          []string
@@ -135,7 +135,7 @@ type healthCheck struct {
 	interval time.Duration
 }
 
-func createStack(svc cloudformationiface.CloudFormationAPI, spec *createStackSpec) (string, error) {
+func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (string, error) {
 	template := templateYAML
 	if spec.customTemplate != "" {
 		template = spec.customTemplate
@@ -175,7 +175,7 @@ func createStack(svc cloudformationiface.CloudFormationAPI, spec *createStackSpe
 	return aws.StringValue(resp.StackId), nil
 }
 
-func updateStack(svc cloudformationiface.CloudFormationAPI, spec *createStackSpec) (string, error) {
+func updateStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (string, error) {
 	template := templateYAML
 	if spec.customTemplate != "" {
 		template = spec.customTemplate

--- a/aws/cf_test.go
+++ b/aws/cf_test.go
@@ -12,28 +12,28 @@ import (
 func TestCreatingStack(t *testing.T) {
 	for _, ti := range []struct {
 		name         string
-		givenSpec    createStackSpec
+		givenSpec    stackSpec
 		givenOutputs cfMockOutputs
 		want         string
 		wantErr      bool
 	}{
 		{
 			"successful-call",
-			createStackSpec{name: "foo", securityGroupID: "bar", vpcID: "baz"},
+			stackSpec{name: "foo", securityGroupID: "bar", vpcID: "baz"},
 			cfMockOutputs{createStack: R(mockCSOutput("fake-stack-id"), nil)},
 			"fake-stack-id",
 			false,
 		},
 		{
 			"successful-call",
-			createStackSpec{name: "foo", securityGroupID: "bar", vpcID: "baz"},
+			stackSpec{name: "foo", securityGroupID: "bar", vpcID: "baz"},
 			cfMockOutputs{createStack: R(mockCSOutput("fake-stack-id"), nil)},
 			"fake-stack-id",
 			false,
 		},
 		{
 			"fail-call",
-			createStackSpec{name: "foo", securityGroupID: "bar", vpcID: "baz"},
+			stackSpec{name: "foo", securityGroupID: "bar", vpcID: "baz"},
 			cfMockOutputs{createStack: R(nil, dummyErr)},
 			"fake-stack-id",
 			true,
@@ -58,19 +58,19 @@ func TestCreatingStack(t *testing.T) {
 func TestDeleteStack(t *testing.T) {
 	for _, ti := range []struct {
 		msg          string
-		givenSpec    createStackSpec
+		givenSpec    stackSpec
 		givenOutputs cfMockOutputs
 		wantErr      bool
 	}{
 		{
 			"delete-existing-stack",
-			createStackSpec{name: "existing-stack-id"},
+			stackSpec{name: "existing-stack-id"},
 			cfMockOutputs{deleteStack: R(mockDeleteStackOutput("existing-stack-id"), nil)},
 			false,
 		},
 		{
 			"delete-non-existing-stack",
-			createStackSpec{name: "non-existing-stack-id"},
+			stackSpec{name: "non-existing-stack-id"},
 			cfMockOutputs{deleteStack: R(mockDeleteStackOutput("existing-stack-id"), nil)},
 			false,
 		},

--- a/controller.go
+++ b/controller.go
@@ -27,6 +27,7 @@ var (
 	healthCheckPort     uint
 	healthcheckInterval time.Duration
 	metricsAddress      string
+	updateStackInterval time.Duration
 )
 
 func loadSettings() error {
@@ -35,6 +36,7 @@ func loadSettings() error {
 		"server base url. If empty will try to use the configuration from the running cluster, else it will use InsecureConfig, that does not use encryption or authentication (use case to develop with kubectl proxy).")
 	flag.DurationVar(&pollingInterval, "polling-interval", 30*time.Second, "sets the polling interval for "+
 		"ingress resources. The flag accepts a value acceptable to time.ParseDuration")
+	flag.DurationVar(&updateStackInterval, "update-stack-interval", 1*time.Hour, "sets the interval for update AWS ALB stack resources, which can fix migrations, if you add for example one subnet to your VPC your ALB has not interface in that. An update stack will add these interfaces automatically. The flag accepts a value acceptable to time.ParseDuration")
 	flag.StringVar(&cfCustomTemplate, "cf-custom-template", "",
 		"filename for a custom cloud formation template to use instead of the built in")
 	flag.DurationVar(&creationTimeout, "creation-timeout", aws.DefaultCreationTimeout,
@@ -59,6 +61,9 @@ func loadSettings() error {
 	}
 
 	if err := loadDurationFromEnv("POLLING_INTERVAL", &pollingInterval); err != nil {
+		return err
+	}
+	if err := loadDurationFromEnv("UPDATE_STACK_INTERVAL", &updateStackInterval); err != nil {
 		return err
 	}
 
@@ -162,7 +167,7 @@ func main() {
 
 	go serveMetrics(metricsAddress)
 	quitCH := make(chan struct{})
-	go startPolling(quitCH, certificatesProvider, awsAdapter, kubeAdapter, pollingInterval)
+	go startPolling(quitCH, certificatesProvider, awsAdapter, kubeAdapter, pollingInterval, updateStackInterval)
 	<-quitCH
 
 	log.Printf("terminating %s", os.Args[0])

--- a/worker.go
+++ b/worker.go
@@ -32,7 +32,7 @@ const (
 	orphan
 )
 
-const ( 
+const (
 	maxTargetGroupSupported = 1000
 )
 
@@ -74,29 +74,29 @@ func startPolling(quitCH chan struct{}, certsProvider certs.CertificatesProvider
 
 func updateStacks(awsAdapter *aws.Adapter, interval time.Duration, items <-chan *managedItem) {
 	for {
-		itemsMap := map[string]*managedItem 
+		itemsMap := map[string]*managedItem{}
 		done := make(chan struct{})
-		go func() { 
-			for { 
-				select { 
-				case item :=<- items :
-					if _, ok := itemsMap[item.stack.certificateARN]; !ok { 
-						itemsMap[item.stack.certificateARN] = item
+		go func() {
+			for {
+				select {
+				case item := <-items:
+					if _, ok := itemsMap[item.stack.CertificateARN()]; !ok {
+						itemsMap[item.stack.CertificateARN()] = item
 					}
-				case <-done: 
+				case <-done:
 					return
 				}
 			}
 		}()
 		time.Sleep(interval)
-		done<-struct{}{}
-		for _, item := range itemsMap { 
+		done <- struct{}{}
+		for _, item := range itemsMap {
 			updateStack(awsAdapter, item)
 		}
 	}
 }
 
-func doWork(certsProvider certs.CertificatesProvider, awsAdapter *aws.Adapter, kubeAdapter *kubernetes.Adapter, items <-chan *managedItem) error {
+func doWork(certsProvider certs.CertificatesProvider, awsAdapter *aws.Adapter, kubeAdapter *kubernetes.Adapter, items chan<- *managedItem) error {
 	defer func() error {
 		if r := recover(); r != nil {
 			log.Println("shit has hit the fan:", errors.Wrap(r.(error), "panic caused by"))

--- a/worker.go
+++ b/worker.go
@@ -98,8 +98,9 @@ func doWork(certsProvider certs.CertificatesProvider, awsAdapter *aws.Adapter, k
 			markToDeleteStack(awsAdapter, managedItem)
 		case missing:
 			createStack(awsAdapter, managedItem)
-			fallthrough
+			updateIngress(kubeAdapter, managedItem)
 		case ready:
+			updateStack(awsAdapter, managedItem)
 			updateIngress(kubeAdapter, managedItem)
 		}
 	}
@@ -165,6 +166,18 @@ func createStack(awsAdapter *aws.Adapter, item *managedItem) {
 		log.Printf("createStack(%q) failed: %v", certificateARN, err)
 	} else {
 		log.Printf("stack %q for certificate %q created", stackId, certificateARN)
+	}
+}
+
+func updateStack(awsAdapter *aws.Adapter, item *managedItem) {
+	certificateARN := item.ingresses[0].CertificateARN()
+	log.Printf("updating stack for certificate %q / ingress %q", certificateARN, item.ingresses)
+
+	stackId, err := awsAdapter.UpdateStack(certificateARN)
+	if err != nil {
+		log.Printf("updateStack(%q) failed: %v", certificateARN, err)
+	} else {
+		log.Printf("stack %q for certificate %q updated", stackId, certificateARN)
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -55,9 +55,9 @@ func waitForTerminationSignals(signals ...os.Signal) chan os.Signal {
 	return c
 }
 
-func startPolling(quitCH chan struct{}, certsProvider certs.CertificatesProvider, awsAdapter *aws.Adapter, kubeAdapter *kubernetes.Adapter, pollingInterval time.Duration) {
+func startPolling(quitCH chan struct{}, certsProvider certs.CertificatesProvider, awsAdapter *aws.Adapter, kubeAdapter *kubernetes.Adapter, pollingInterval, updateStackInterval time.Duration) {
 	items := make(chan *managedItem, maxTargetGroupSupported)
-	go updateStacks(awsAdapter, 1*time.Hour, items)
+	go updateStacks(awsAdapter, updateStackInterval, items)
 	for {
 		log.Printf("Start polling sleep %s", pollingInterval)
 		select {


### PR DESCRIPTION
To fix migrations, for example 2AZs to 3AZs we have to update all CF stacks which we currently have.
This PR is not ready yet, because we need to have a flag to enable migrations or another goroutine which does the updateStack calls in a slower iteration than every minute.