### PR TITLE
Build.docker should not depend on build.linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build/linux/$(BINARY): $(SOURCES)
 build/osx/$(BINARY): $(SOURCES)
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/osx/$(BINARY) -ldflags "$(LDFLAGS)" .
 
-build.docker: build.linux
+build.docker:
 	docker build -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) .
 
 build.push: build.docker


### PR DESCRIPTION
Since we have docker multistage build in place, building the application on the host is not needed anymore