### PR TITLE
Support specifying cert domain via annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,35 @@ spec:
 The Application Load Balancer created by the controller will have both an HTTP listener and an HTTPS listener. The
 latter will use the automatically selected certificate.
 
-Alternatively, you can specify the [Amazon Resource Name](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) (ARN)
+Alternatively, you can specify a domain used for automatically selecting a
+certificate with an annotation like the one shown below. This is useful if you
+have multiple hosts rules defined and want to make sure to select a certificate
+for the right hostname.
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: myingress
+  annotations:
+    zalando.org/aws-load-balancer-ssl-cert-domain: alt.name.org
+spec:
+  rules:
+  - host: test-app.example.org
+    http:
+      paths:
+      - backend:
+          serviceName: test-app-service
+          servicePort: main-port
+  - host: alt.name.org
+    http:
+      paths:
+      - backend:
+          serviceName: test-app-service
+          servicePort: main-port
+```
+
+As a third option you can specify the [Amazon Resource Name](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) (ARN)
 of the desired certificate with an annotation like the one shown here:
 
 ```yaml

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -82,6 +82,11 @@ func newIngressFromKube(kubeIngress *ingress) *Ingress {
 		}
 	}
 
+	certDomain := kubeIngress.getAnnotationsString(ingressCertificateDomainAnnotation, "")
+	if certDomain != "" {
+		certHostname = certDomain
+	}
+
 	return &Ingress{
 		certificateARN: kubeIngress.getAnnotationsString(ingressCertificateARNAnnotation, ""),
 		namespace:      kubeIngress.Metadata.Namespace,

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -60,6 +60,27 @@ func TestMappingRoundtrip(t *testing.T) {
 	}
 }
 
+func TestCertDomainAnnotation(t *testing.T) {
+	certDomain := "foo.org"
+
+	kubeMeta := ingressItemMetadata{
+		Namespace: "default",
+		Name:      "foo",
+		Annotations: map[string]interface{}{
+			ingressCertificateARNAnnotation:    "zbr",
+			ingressCertificateDomainAnnotation: certDomain,
+		},
+	}
+	kubeIngress := &ingress{
+		Metadata: kubeMeta,
+	}
+
+	got := newIngressFromKube(kubeIngress)
+	if got.CertHostname() != certDomain {
+		t.Errorf("expected cert hostname %s, got %s", certDomain, got.CertHostname())
+	}
+}
+
 func TestInsecureConfig(t *testing.T) {
 	cfg := InsecureConfig("http://domain.com:12345")
 	if cfg.BaseURL != "http://domain.com:12345" {

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -59,9 +59,10 @@ type ingressLoadBalancer struct {
 }
 
 const (
-	ingressListResource             = "/apis/extensions/v1beta1/ingresses"
-	ingressPatchStatusResource      = "/apis/extensions/v1beta1/namespaces/%s/ingresses/%s/status"
-	ingressCertificateARNAnnotation = "zalando.org/aws-load-balancer-ssl-cert"
+	ingressListResource                = "/apis/extensions/v1beta1/ingresses"
+	ingressPatchStatusResource         = "/apis/extensions/v1beta1/namespaces/%s/ingresses/%s/status"
+	ingressCertificateARNAnnotation    = "zalando.org/aws-load-balancer-ssl-cert"
+	ingressCertificateDomainAnnotation = "zalando.org/aws-load-balancer-ssl-cert-domain"
 )
 
 func (i *ingress) getAnnotationsString(key string, defaultValue string) string {


### PR DESCRIPTION
Supports specifying domain for matching a cert via the
`zalando.org/aws-load-balancer-ssl-cert-domain` annotation.

This partly solves #81 by supporting the use case for a single domain.

/cc @szuecs