### PR TITLE
Always build against latest stable Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM golang:1.8 as builder
+FROM golang as builder
 
 RUN go get github.com/Masterminds/glide
 WORKDIR /go/src/github.com/zalando-incubator/kube-ingress-aws-controller


### PR DESCRIPTION
Use the `latest` golang docker image as build image which always resolves to the current stable release of Go.

I consider Go stable enough that it's ok to not pin the build to a particular version, but instead automatically build against the latest stable version.