### PR TITLE
Check that specified certificate ARN exists before creating stack

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -156,6 +156,12 @@ func buildManagedModel(certsProvider certs.CertificatesProvider, ingresses []*ku
 				log.Printf("failed to find a certificate for %v: %v", ingress.CertHostname(), err)
 				continue
 			}
+		} else { // validate that certificateARN exists
+			err := checkCertificate(certsProvider, certificateARN)
+			if err != nil {
+				log.Printf("Failed to find certificate with ARN %s: %v", certificateARN, err)
+				continue
+			}
 		}
 		if item, ok := model[certificateARN]; ok {
 			item.ingresses = append(item.ingresses, ingress)
@@ -179,6 +185,23 @@ func discoverCertificateAndUpdateIngress(certsProvider certs.CertificatesProvide
 	}
 	ingress.SetCertificateARN(certificateSummary.ID())
 	return certificateSummary.ID(), nil
+}
+
+// checkCertificate checks that a certificate with the specified ARN exists in
+// the account. Returns error if no certificate is found.
+func checkCertificate(certsProvider certs.CertificatesProvider, arn string) error {
+	certs, err := certsProvider.GetCertificates()
+	if err != nil {
+		return err
+	}
+
+	for _, cert := range certs {
+		if arn == cert.ID() {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("certificate not found")
 }
 
 func createStack(awsAdapter *aws.Adapter, item *managedItem) {


### PR DESCRIPTION
Checks that the ARN specified in the `zalando.org/aws-load-balancer-ssl-cert` annotation exists in the account before creating a stack. If it doesn't exist then no stack/ALB is created and an error is logged.

This ensures that the ingress-controller doesn't create/delete ALBs forever if a user specifies the wrong ARN.

Fix #86 (Not possible to set an error status on the ingress object, so it just logs the error).