### PR TITLE
Update go version used in travis, allow tip to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ os:
 language: go
 
 go:
-- 1.7
+- 1.9
 - tip
+
+matrix:
+  allow_failures:
+  - go: tip
 
 before_install:
 - go get github.com/Masterminds/glide


### PR DESCRIPTION
Updates the go version used in travis to the latest stable version (1.9) and allows builds for go tip version to fail.