### PR TITLE
Add support for legacy KubernetesCluster tag

### DIFF
--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -10,14 +10,15 @@ import (
 )
 
 const (
-	defaultClusterID        = "unknown-cluster"
-	clusterIDTag            = "ClusterID" // TODO(sszuecs): deprecated fallback cleanup
-	clusterIDTagPrefix      = "kubernetes.io/cluster/"
-	resourceLifecycleOwned  = "owned"
-	kubernetesCreatorTag    = "kubernetes:application"
-	kubernetesCreatorValue  = "kube-ingress-aws-controller"
-	autoScalingGroupNameTag = "aws:autoscaling:groupName"
-	runningState            = 16 // See https://github.com/aws/aws-sdk-go/blob/master/service/ec2/api.go, type InstanceState
+	defaultClusterID           = "unknown-cluster"
+	kubernetesClusterLegacyTag = "KubernetesCluster"
+	clusterIDTag               = "ClusterID" // TODO(sszuecs): deprecated fallback cleanup
+	clusterIDTagPrefix         = "kubernetes.io/cluster/"
+	resourceLifecycleOwned     = "owned"
+	kubernetesCreatorTag       = "kubernetes:application"
+	kubernetesCreatorValue     = "kube-ingress-aws-controller"
+	autoScalingGroupNameTag    = "aws:autoscaling:groupName"
+	runningState               = 16 // See https://github.com/aws/aws-sdk-go/blob/master/service/ec2/api.go, type InstanceState
 )
 
 type securityGroupDetails struct {
@@ -35,6 +36,11 @@ func (id *instanceDetails) clusterID() string {
 	for name, value := range id.tags {
 		if strings.HasPrefix(name, clusterIDTagPrefix) && value == resourceLifecycleOwned {
 			return strings.TrimPrefix(name, clusterIDTagPrefix)
+		}
+	}
+	for name, value := range id.tags {
+		if name == kubernetesClusterLegacyTag {
+			return value
 		}
 	}
 	return defaultClusterID

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -70,6 +70,21 @@ func TestInstanceDetails(t *testing.T) {
 			wantClusterID: "zbr",
 		},
 		{
+			given: instanceDetails{id: "this-should-be-fine-legacy", vpcID: "bar", tags: map[string]string{
+				nameTag:                    "baz",
+				kubernetesClusterLegacyTag: "zbr",
+			}},
+			wantClusterID: "zbr",
+		},
+		{
+			given: instanceDetails{id: "this-should-be-fine-new-plus-legacy", vpcID: "bar", tags: map[string]string{
+				nameTag:                    "foo",
+				kubernetesClusterLegacyTag: "bar",
+				clusterIDTagPrefix + "baz": resourceLifecycleOwned,
+			}},
+			wantClusterID: "baz",
+		},
+		{
 			given: instanceDetails{id: "missing-name-tag", vpcID: "bar", tags: map[string]string{
 				clusterIDTagPrefix + "zbr": resourceLifecycleOwned,
 			}},


### PR DESCRIPTION
This adds support for the legacy KubernetesCluster tag as a fallback
when detecting clusterID from the host instance.

This is to support kops which still use the old tag for the ec2
instances.

The new tag kubernetes.io/cluster/<cluster-id> will still be used and
expected by the ingress controller for the security group and the stack
that is created.