### PR TITLE
Limit to tagged ELB subnets if found

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -340,6 +340,23 @@ func buildManifest(awsAdapter *Adapter) (*manifest, error) {
 	}
 
 	var (
+		elbRole []*subnetDetails
+	)
+
+	// Filter for subnets declaring the ELB role.
+	for _, subnet := range subnets {
+		if subnet.elbRole {
+			elbRole = append(elbRole, subnet)
+		}
+	}
+
+	// If there's at least one subnet declaring the ELB role, use only the tagged subnets.
+	// Otherwise use all found subnets.
+	if len(elbRole) > 0 {
+		subnets = elbRole
+	}
+
+	var (
 		priv []*subnetDetails
 		pub  []*subnetDetails
 	)

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -172,7 +172,7 @@ func TestGetSubnets(t *testing.T) {
 			"success-call",
 			ec2MockOutputs{
 				describeSubnets: R(mockDSOutput(
-					testSubnet{id: "foo1", name: "bar1", az: "baz1"},
+					testSubnet{id: "foo1", name: "bar1", az: "baz1", tags: map[string]string{elbRoleTagName: ""}},
 					testSubnet{id: "foo2", name: "bar2", az: "baz2"},
 				), nil),
 				describeRouteTables: R(mockDRTOutput(
@@ -181,8 +181,8 @@ func TestGetSubnets(t *testing.T) {
 				), nil),
 			},
 			[]*subnetDetails{
-				{id: "foo1", availabilityZone: "baz1", public: true, tags: map[string]string{nameTag: "bar1"}},
-				{id: "foo2", availabilityZone: "baz2", public: true, tags: map[string]string{nameTag: "bar2"}},
+				{id: "foo1", availabilityZone: "baz1", public: true, tags: map[string]string{nameTag: "bar1", elbRoleTagName: ""}, elbRole: true},
+				{id: "foo2", availabilityZone: "baz2", public: true, tags: map[string]string{nameTag: "bar2"}, elbRole: false},
 			},
 			false,
 		},

--- a/aws/ec2mock_test.go
+++ b/aws/ec2mock_test.go
@@ -85,6 +85,7 @@ type testSubnet struct {
 	id   string
 	az   string
 	name string
+	tags map[string]string
 }
 
 func mockDSOutput(mockedSubnets ...testSubnet) *ec2.DescribeSubnetsOutput {
@@ -96,6 +97,9 @@ func mockDSOutput(mockedSubnets ...testSubnet) *ec2.DescribeSubnetsOutput {
 			Tags: []*ec2.Tag{
 				{Key: aws.String(nameTag), Value: aws.String(subnet.name)},
 			},
+		}
+		for k, v := range subnet.tags {
+			s.Tags = append(s.Tags, &ec2.Tag{Key: aws.String(k), Value: aws.String(v)})
 		}
 		subnets = append(subnets, s)
 	}


### PR DESCRIPTION
This limits the found subnets to the ones tagged with either `kubernetes.io/role/elb` or `kubernetes.io/role/internal-elb` in order to control which subnets are picked in case there are many.

If no subnet is tagged with either annotation then we assume there's no need to identify them and return the entire list. This is equivalent to the current behaviour.

Fixes: https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/102