### PR TITLE
Add annotation to select scheme for elb creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ metadata:
   name: myingress
   annotations:
     zalando.org/aws-load-balancer-ssl-cert-domain: alt.name.org
+    zalando.org/aws-load-balancer-scheme: internal
 spec:
   rules:
   - host: test-app.example.org
@@ -160,6 +161,28 @@ spec:
           serviceName: test-app-service
           servicePort: main-port
 ```
+
+You can select the [Application Load Balancer Scheme ](http://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html#load-balancer-scheme)
+with an annotation like the one shown here:
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: myingress
+  annotations:
+    zalando.org/aws-load-balancer-scheme: internal
+spec:
+  rules:
+  - host: test-app.example.org
+    http:
+      paths:
+      - backend:
+          serviceName: test-app-service
+          servicePort: main-port
+```
+
+You can only select from internet-facing (default) and internal options.
 
 The new Application Load Balancers have a custom tag marking them as *managed* load balancers to differentiate them
 from other load balancers. The tag looks like this:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ metadata:
   name: myingress
   annotations:
     zalando.org/aws-load-balancer-ssl-cert-domain: alt.name.org
-    zalando.org/aws-load-balancer-scheme: internal
 spec:
   rules:
   - host: test-app.example.org
@@ -162,7 +161,7 @@ spec:
           servicePort: main-port
 ```
 
-You can select the [Application Load Balancer Scheme ](http://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html#load-balancer-scheme)
+You can select the [Application Load Balancer Scheme](http://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html#load-balancer-scheme)
 with an annotation like the one shown here:
 
 ```yaml
@@ -182,7 +181,7 @@ spec:
           servicePort: main-port
 ```
 
-You can only select from internet-facing (default) and internal options.
+You can only select from `internet-facing` (default) and `internal` options.
 
 The new Application Load Balancers have a custom tag marking them as *managed* load balancers to differentiate them
 from other load balancers. The tag looks like this:

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/linki/instrumented_http"
@@ -230,10 +229,10 @@ func (a *Adapter) FindManagedStacks() ([]*Stack, error) {
 // from the Cluster ID and the certificate ARN (when available).
 // All the required resources (listeners and target group) are created in a transactional fashion.
 // Failure to create the stack causes it to be deleted automatically.
-func (a *Adapter) CreateStack(certificateARN string) (string, error) {
+func (a *Adapter) CreateStack(certificateARN string, scheme string) (string, error) {
 	spec := &stackSpec{
 		name:            a.stackName(certificateARN),
-		scheme:          elbv2.LoadBalancerSchemeEnumInternetFacing,
+		scheme:          scheme,
 		certificateARN:  certificateARN,
 		securityGroupID: a.SecurityGroupID(),
 		subnets:         a.PublicSubnetIDs(),
@@ -250,10 +249,10 @@ func (a *Adapter) CreateStack(certificateARN string) (string, error) {
 	return createStack(a.cloudformation, spec)
 }
 
-func (a *Adapter) UpdateStack(certificateARN string) (string, error) {
+func (a *Adapter) UpdateStack(certificateARN string, scheme string) (string, error) {
 	spec := &stackSpec{
 		name:            a.stackName(certificateARN),
-		scheme:          elbv2.LoadBalancerSchemeEnumInternetFacing,
+		scheme:          scheme,
 		certificateARN:  certificateARN,
 		securityGroupID: a.SecurityGroupID(),
 		subnets:         a.PublicSubnetIDs(),

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -22,6 +22,7 @@ const (
 type Stack struct {
 	name           string
 	dnsName        string
+	scheme         string
 	targetGroupARN string
 	certificateARN string
 	tags           map[string]string
@@ -33,6 +34,10 @@ func (s *Stack) Name() string {
 
 func (s *Stack) DNSName() string {
 	return s.dnsName
+}
+
+func (s *Stack) Scheme() string {
+	return s.scheme
 }
 
 func (s *Stack) CertificateARN() string {
@@ -96,6 +101,10 @@ func newStackOutput(outputs []*cloudformation.Output) stackOutput {
 
 func (o stackOutput) dnsName() string {
 	return o[outputLoadBalancerDNSName]
+}
+
+func (o stackOutput) scheme() string {
+	return o[parameterLoadBalancerSchemeParameter]
 }
 
 func (o stackOutput) targetGroupARN() string {
@@ -292,6 +301,7 @@ func mapToManagedStack(stack *cloudformation.Stack) *Stack {
 	return &Stack{
 		name:           aws.StringValue(stack.StackName),
 		dnsName:        o.dnsName(),
+		scheme :        o.scheme(),
 		targetGroupARN: o.targetGroupARN(),
 		certificateARN: t[certificateARNTag],
 		tags:           convertCloudFormationTags(stack.Tags),

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
+        "github.com/aws/aws-sdk-go/service/elbv2"
 )
 
 type Adapter struct {
@@ -103,7 +104,7 @@ func newIngressFromKube(kubeIngress *ingress) *Ingress {
 		namespace:      kubeIngress.Metadata.Namespace,
 		name:           kubeIngress.Metadata.Name,
 		hostName:       host,
-		scheme:         kubeIngress.getAnnotationsString(ingressSchemeAnnotation, "internet-facing"),
+		scheme:         kubeIngress.getAnnotationsString(ingressSchemeAnnotation, elbv2.LoadBalancerSchemeEnumInternetFacing),
 		certHostname:   certHostname,
 	}
 }

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -35,6 +35,7 @@ type Ingress struct {
 	namespace      string
 	name           string
 	hostName       string
+	scheme         string
 	certHostname   string
 }
 
@@ -55,6 +56,11 @@ func (i *Ingress) Hostname() string {
 	return i.hostName
 }
 
+// Scheme returns the scheme associated with the ingress
+func (i *Ingress) Scheme() string {
+       return i.scheme
+}
+
 // CertHostname returns the DNS hostname associated with the ingress
 // gotten from Kubernetes Spec
 func (i *Ingress) CertHostname() string {
@@ -64,6 +70,11 @@ func (i *Ingress) CertHostname() string {
 // SetCertificateARN sets Ingress.certificateARN to the arn as specified.
 func (i *Ingress) SetCertificateARN(arn string) {
 	i.certificateARN = arn
+}
+
+// SetScheme sets Ingress.scheme to the scheme as specified.
+func (i *Ingress) SetScheme(scheme string) {
+       i.scheme = scheme
 }
 
 func newIngressFromKube(kubeIngress *ingress) *Ingress {
@@ -92,6 +103,7 @@ func newIngressFromKube(kubeIngress *ingress) *Ingress {
 		namespace:      kubeIngress.Metadata.Namespace,
 		name:           kubeIngress.Metadata.Name,
 		hostName:       host,
+		scheme:         kubeIngress.getAnnotationsString(ingressSchemeAnnotation, "internet-facing"),
 		certHostname:   certHostname,
 	}
 }
@@ -103,6 +115,7 @@ func newIngressForKube(i *Ingress) *ingress {
 			Name:      i.name,
 			Annotations: map[string]interface{}{
 				ingressCertificateARNAnnotation: i.certificateARN,
+				ingressSchemeAnnotation: i.scheme,
 			},
 		},
 		Status: ingressStatus{

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -16,6 +16,7 @@ func TestMappingRoundtrip(t *testing.T) {
 		namespace:      "default",
 		name:           "foo",
 		hostName:       "bar",
+		scheme:         "internal",
 		certificateARN: "zbr",
 	}
 
@@ -24,6 +25,7 @@ func TestMappingRoundtrip(t *testing.T) {
 		Name:      "foo",
 		Annotations: map[string]interface{}{
 			ingressCertificateARNAnnotation: "zbr",
+			ingressSchemeAnnotation: "internal",
 		},
 	}
 	kubeStatus := ingressStatus{

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -48,6 +48,9 @@ func TestMappingRoundtrip(t *testing.T) {
 	if got.CertificateARN() != kubeIngress.Metadata.Annotations[ingressCertificateARNAnnotation] {
 		t.Error("wrong value from CertificateARN()")
 	}
+	if got.Scheme() != kubeIngress.Metadata.Annotations[ingressSchemeAnnotation] {
+		t.Error("wrong value from Scheme()")
+	}
 	if got.Hostname() != kubeIngress.Status.LoadBalancer.Ingress[1].Hostname {
 		t.Error("wrong value from Hostname()")
 	}

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -63,6 +63,7 @@ const (
 	ingressPatchStatusResource         = "/apis/extensions/v1beta1/namespaces/%s/ingresses/%s/status"
 	ingressCertificateARNAnnotation    = "zalando.org/aws-load-balancer-ssl-cert"
 	ingressCertificateDomainAnnotation = "zalando.org/aws-load-balancer-ssl-cert-domain"
+	ingressSchemeAnnotation            = "zalando.org/aws-load-balancer-scheme"
 )
 
 func (i *ingress) getAnnotationsString(key string, defaultValue string) string {

--- a/worker.go
+++ b/worker.go
@@ -206,9 +206,10 @@ func checkCertificate(certsProvider certs.CertificatesProvider, arn string) erro
 
 func createStack(awsAdapter *aws.Adapter, item *managedItem) {
 	certificateARN := item.ingresses[0].CertificateARN()
-	log.Printf("creating stack for certificate %q / ingress %q", certificateARN, item.ingresses)
+	scheme := item.ingresses[0].Scheme()
+	log.Printf("creating %q stack for certificate %q / ingress %q", scheme, certificateARN, item.ingresses)
 
-	stackId, err := awsAdapter.CreateStack(certificateARN)
+	stackId, err := awsAdapter.CreateStack(certificateARN,scheme)
 	if err != nil {
 		if isAlreadyExistsError(err) {
 			item.stack, err = awsAdapter.GetStack(stackId)
@@ -224,9 +225,10 @@ func createStack(awsAdapter *aws.Adapter, item *managedItem) {
 
 func updateStack(awsAdapter *aws.Adapter, item *managedItem) {
 	certificateARN := item.ingresses[0].CertificateARN()
-	log.Printf("updating stack for certificate %q / ingress %q", certificateARN, item.ingresses)
+	scheme := item.ingresses[0].Scheme()
+	log.Printf("updating %q stack for certificate %q / ingress %q", scheme, certificateARN, item.ingresses)
 
-	stackId, err := awsAdapter.UpdateStack(certificateARN)
+	stackId, err := awsAdapter.UpdateStack(certificateARN,scheme)
 	if isNoUpdatesToBePerformedError(err) {
 		log.Printf("stack(%q) is already up to date", certificateARN)
 	} else if err != nil {


### PR DESCRIPTION
Related to the [Support "internal" Application Load Balancers](https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/22) issue.

I add a zalando annotation to select internet-facing (default) or internal scheme to ELB
