### PR TITLE
Group ingresses by ingress scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,24 @@ This information is used to manage AWS resources for each ingress objects of the
 - Automatic discovery of SSL certificates
 - Automatic forwarding of requests to all Worker Nodes, even with auto scaling
 - Automatic cleanup of unnecessary managed resources
+- Support for internet-facing and internal load balancers
 - Can be used in clusters created by [Kops](https://github.com/kubernetes/kops), see our [deployment guide for Kops](deploy/kops.md)
 
 ## Upgrade
 
+### <v0.5.0 to >=v0.5.0
+
+Version `v0.5.0` introduced support for both `internet-facing` and `internal`
+load balancers. For this change we had to change the naming of the
+CloudFormation stacks created by the controller. To upgrade from v0.4.* to
+v0.5.0 no changes are needed, but since the naming change of the stacks
+migrating back down to a v0.4.* version will not be non-disruptive as it will
+be unable to manage the stacks with the new naming scheme. Deleting the stacks
+manually will allow for a working downgrade.
+
 ### <v0.4.0 to >=v0.4.0
 
-In versions before v.04.0 we used AWS Tags that were set by CloudFormation automatically to find
+In versions before v0.4.0 we used AWS Tags that were set by CloudFormation automatically to find
 some AWS resources.
 This behavior has been changed to use custom non cloudformation tags.
 
@@ -87,7 +98,7 @@ On startup, the controller discovers the AWS resources required for the controll
 
 2. The Security Group
 
-    Lookup of the `kubernetes.io/cluster/<cluster-id>` tag of the Security Group matching the clusterID for the controller node and `kubernetes:application` matching the value `kube-ingress-aws-controller` or as fallback for <v0.4.0
+    Lookup of the `kubernetes.io/cluster/<cluster-id>` tag of the Security Group matching the clusterID for the controller node and `kubernetes:application` matching the value `kube-ingress-aws-controller` or as fallback for `<v0.4.0`
     tag `aws:cloudformation:logical-id` matching the value `IngressLoadBalancerSecurityGroup` (only clusters created by CF).
 
 ### Creating Load Balancers

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -229,9 +229,9 @@ func (a *Adapter) FindManagedStacks() ([]*Stack, error) {
 // from the Cluster ID and the certificate ARN (when available).
 // All the required resources (listeners and target group) are created in a transactional fashion.
 // Failure to create the stack causes it to be deleted automatically.
-func (a *Adapter) CreateStack(certificateARN string, scheme string) (string, error) {
+func (a *Adapter) CreateStack(certificateARN, scheme string) (string, error) {
 	spec := &stackSpec{
-		name:            a.stackName(certificateARN),
+		name:            a.stackName(certificateARN, scheme),
 		scheme:          scheme,
 		certificateARN:  certificateARN,
 		securityGroupID: a.SecurityGroupID(),
@@ -249,9 +249,9 @@ func (a *Adapter) CreateStack(certificateARN string, scheme string) (string, err
 	return createStack(a.cloudformation, spec)
 }
 
-func (a *Adapter) UpdateStack(certificateARN string, scheme string) (string, error) {
+func (a *Adapter) UpdateStack(stackName, certificateARN, scheme string) (string, error) {
 	spec := &stackSpec{
-		name:            a.stackName(certificateARN),
+		name:            stackName,
 		scheme:          scheme,
 		certificateARN:  certificateARN,
 		securityGroupID: a.SecurityGroupID(),
@@ -269,8 +269,8 @@ func (a *Adapter) UpdateStack(certificateARN string, scheme string) (string, err
 	return updateStack(a.cloudformation, spec)
 }
 
-func (a *Adapter) stackName(certificateARN string) string {
-	return normalizeStackName(a.ClusterID(), certificateARN)
+func (a *Adapter) stackName(certificateARN, scheme string) string {
+	return normalizeStackName(a.ClusterID(), certificateARN, scheme)
 }
 
 // GetStack returns the CloudFormation stack details with the name or ID from the argument
@@ -282,7 +282,7 @@ func (a *Adapter) GetStack(stackID string) (*Stack, error) {
 func (a *Adapter) MarkToDeleteStack(stack *Stack) (time.Time, error) {
 	t0 := time.Now().Add(a.stackTTL)
 
-	return t0, markToDeleteStack(a.cloudformation, a.stackName(stack.CertificateARN()), t0.Format(time.RFC3339))
+	return t0, markToDeleteStack(a.cloudformation, stack.Name(), t0.Format(time.RFC3339))
 }
 
 // DeleteStack deletes the CloudFormation stack with the given name

--- a/aws/cf_test.go
+++ b/aws/cf_test.go
@@ -170,6 +170,31 @@ func TestTagConversion(t *testing.T) {
 
 }
 
+func TestConvertStackParameters(t *testing.T) {
+	for _, ti := range []struct {
+		name  string
+		given []*cloudformation.Parameter
+		want  map[string]string
+	}{
+		{"default", []*cloudformation.Parameter{
+			{
+				ParameterKey:   aws.String("foo"),
+				ParameterValue: aws.String("bar"),
+			},
+		}, map[string]string{"foo": "bar"}},
+		{"empty-input", []*cloudformation.Parameter{}, map[string]string{}},
+		{"nil-input", nil, map[string]string{}},
+	} {
+		t.Run(ti.name, func(t *testing.T) {
+			got := convertStackParameters(ti.given)
+			if !reflect.DeepEqual(ti.want, got) {
+				t.Errorf("unexpected result. wanted %+v, got %+v", ti.want, got)
+			}
+		})
+	}
+
+}
+
 func TestFindingManagedStacks(t *testing.T) {
 	for _, ti := range []struct {
 		name    string

--- a/aws/naming.go
+++ b/aws/naming.go
@@ -11,8 +11,8 @@ import (
 
 // The Namer interface defines the behavior of types that are able to apply custom constraints to names of resources
 type Namer interface {
-	// Returns a normalized name from the combination of both arguments
-	Normalize(clusterID, certificateARN string) string
+	// Returns a normalized name from the combination of the arguments
+	Normalize(clusterID, certificateARN, scheme string) string
 }
 
 // SHA1 Hash ARN, keep last 7 hex chars
@@ -43,7 +43,7 @@ var (
 // Normalize returns a normalized name which replaces invalid characters from the ClusterID with '-' and appends the
 // last 7 chars of the SHA1 hash of the certificateARN. If the length of the normalized clusterID exceeds 24 chars, the
 // it is truncated so that its concatenation with a '-' char and the hash part don't exceed 32 chars.
-func (n *awsResourceNamer) Normalize(clusterID, certificateARN string) string {
+func (n *awsResourceNamer) Normalize(clusterID, certificateARN, scheme string) string {
 	hasher := sha1.New()
 	if certificateARN == "" {
 		binary.Write(hasher, binary.BigEndian, emptyARN)
@@ -65,7 +65,7 @@ func (n *awsResourceNamer) Normalize(clusterID, certificateARN string) string {
 	}
 	normalizedClusterID = strings.Trim(normalizedClusterID, nameSeparator) // trim leading/trailing separators
 
-	return fmt.Sprintf("%s%s%s", normalizedClusterID, nameSeparator, hash)
+	return fmt.Sprintf("%s%s%s-%s", normalizedClusterID, nameSeparator, hash, scheme)
 }
 
 var (
@@ -73,10 +73,6 @@ var (
 	loadBalancerNamer = &awsResourceNamer{maxLen: maxLoadBalancerNameLen}
 )
 
-func normalizeStackName(clusterID, certificateARN string) string {
-	return stackNamer.Normalize(clusterID, certificateARN)
-}
-
-func normalizeLoadBalancerName(clusterID, certificateARN string) string {
-	return loadBalancerNamer.Normalize(clusterID, certificateARN)
+func normalizeStackName(clusterID, certificateARN, scheme string) string {
+	return stackNamer.Normalize(clusterID, certificateARN, scheme)
 }

--- a/aws/naming_test.go
+++ b/aws/naming_test.go
@@ -5,56 +5,56 @@ import (
 	"testing"
 )
 
-var testNamers = map[string]func(string, string) string{
+var testNamers = map[string]func(string, string, string) string{
 	"stack": normalizeStackName,
-	"elb":   normalizeLoadBalancerName,
 }
 
 func TestNormalization(t *testing.T) {
 	for _, test := range []struct {
 		clusterID string
 		arn       string
+		scheme    string
 		want      map[string]string
 	}{
 		{
 			"playground",
 			"arn:aws:acm:eu-central-1:123456789012:certificate/f4bd7ed6-bf23-11e6-8db1-ef7ba1500c61",
-			map[string]string{"": "playground-7cf27d0"},
+			"internet-facing",
+			map[string]string{"": "playground-7cf27d0-internet-facing"},
 		},
-		{"foo", "", map[string]string{"": "foo-fd80709"}},
-		{"foo", "bar", map[string]string{"": "foo-1f01f4d"}},
-		{"foo", "fake-cert-arn", map[string]string{"": "foo-f398861"}},
-		{"test/with-invalid+chars", "bar", map[string]string{"": "test-with-invalid-chars-1f01f4d"}},
-		{"-apparently-valid-name", "bar", map[string]string{"": "apparently-valid-name-1f01f4d"}},
-		{"apparently-valid-name-", "bar", map[string]string{"": "apparently-valid-name-1f01f4d"}},
-		{"valid--name", "bar", map[string]string{"": "valid-name-1f01f4d"}},
-		{"valid-----name", "bar", map[string]string{"": "valid-name-1f01f4d"}},
-		{"foo bar baz zbr", "bar", map[string]string{"": "foo-bar-baz-zbr-1f01f4d"}},
-		{"very long cluster where lb but not stack id needs to be truncated", "bar", map[string]string{
-			"elb":   "id-needs-to-be-truncated-1f01f4d",
-			"stack": "very-long-cluster-where-lb-but-not-stack-id-needs-to-be-truncated-1f01f4d",
+		{"foo", "", "internet-facing", map[string]string{"": "foo-fd80709-internet-facing"}},
+		{"foo", "bar", "internet-facing", map[string]string{"": "foo-1f01f4d-internet-facing"}},
+		{"foo", "fake-cert-arn", "internet-facing", map[string]string{"": "foo-f398861-internet-facing"}},
+		{"test/with-invalid+chars", "bar", "internet-facing", map[string]string{"": "test-with-invalid-chars-1f01f4d-internet-facing"}},
+		{"-apparently-valid-name", "bar", "internet-facing", map[string]string{"": "apparently-valid-name-1f01f4d-internet-facing"}},
+		{"apparently-valid-name-", "bar", "internet-facing", map[string]string{"": "apparently-valid-name-1f01f4d-internet-facing"}},
+		{"valid--name", "bar", "internet-facing", map[string]string{"": "valid-name-1f01f4d-internet-facing"}},
+		{"valid-----name", "bar", "internet-facing", map[string]string{"": "valid-name-1f01f4d-internet-facing"}},
+		{"foo bar baz zbr", "bar", "internet-facing", map[string]string{"": "foo-bar-baz-zbr-1f01f4d-internet-facing"}},
+		{"very long cluster where lb but not stack id needs to be truncated", "bar", "internet-facing", map[string]string{
+			"stack": "very-long-cluster-where-lb-but-not-stack-id-needs-to-be-truncated-1f01f4d-internet-facing",
 		}},
-		{"-no---need---to---truncate-", "", map[string]string{"": "no-need-to-truncate-fd80709"}},
+		{"-no---need---to---truncate-", "", "internet-facing", map[string]string{"": "no-need-to-truncate-fd80709-internet-facing"}},
 		{
 			"aws:170858875137:eu-central-1:kube-aws-test-ingctl001",
 			"arn:aws:acm:eu-central-1:123456789012:certificate/f4bd7ed6-bf23-11e6-8db1-ef7ba1500c61",
+			"internet-facing",
 			map[string]string{
-				"elb":   "kube-aws-test-ingctl001-7cf27d0",
-				"stack": "aws-170858875137-eu-central-1-kube-aws-test-ingctl001-7cf27d0",
+				"stack": "aws-170858875137-eu-central-1-kube-aws-test-ingctl001-7cf27d0-internet-facing",
 			},
 		},
 		{
 			"some very long cluster id tha is supposed to test the limits of the stack namer maximum length and truncate this at some point",
 			"bar",
+			"internet-facing",
 			map[string]string{
-				"elb":   "ncate-this-at-some-point-1f01f4d",
-				"stack": "ery-long-cluster-id-tha-is-supposed-to-test-the-limits-of-the-stack-namer-maximum-length-and-truncate-this-at-some-point-1f01f4d",
+				"stack": "ery-long-cluster-id-tha-is-supposed-to-test-the-limits-of-the-stack-namer-maximum-length-and-truncate-this-at-some-point-1f01f4d-internet-facing",
 			},
 		},
 	} {
 		for namerKey, namerFunc := range testNamers {
 			t.Run(fmt.Sprintf("%s/%s", namerKey, test.want), func(t *testing.T) {
-				got := namerFunc(test.clusterID, test.arn)
+				got := namerFunc(test.clusterID, test.arn, test.scheme)
 				var want string
 				want, has := test.want[namerKey]
 				if !has {

--- a/worker.go
+++ b/worker.go
@@ -228,7 +228,7 @@ func updateStack(awsAdapter *aws.Adapter, item *managedItem) {
 	scheme := item.ingresses[0].Scheme()
 	log.Printf("updating %q stack for certificate %q / ingress %q", scheme, certificateARN, item.ingresses)
 
-	stackId, err := awsAdapter.UpdateStack(certificateARN, scheme)
+	stackId, err := awsAdapter.UpdateStack(item.stack.Name(), certificateARN, scheme)
 	if isNoUpdatesToBePerformedError(err) {
 		log.Printf("stack(%q) is already up to date", certificateARN)
 	} else if err != nil {

--- a/worker.go
+++ b/worker.go
@@ -141,7 +141,7 @@ func doWork(certsProvider certs.CertificatesProvider, awsAdapter *aws.Adapter, k
 func buildManagedModel(certsProvider certs.CertificatesProvider, ingresses []*kubernetes.Ingress, stacks []*aws.Stack) map[string]*managedItem {
 	model := make(map[string]*managedItem)
 	for _, stack := range stacks {
-		model[stack.CertificateARN()] = &managedItem{stack: stack}
+		model[stack.CertificateARN()+"/"+stack.Scheme()] = &managedItem{stack: stack}
 	}
 
 	var (
@@ -163,10 +163,10 @@ func buildManagedModel(certsProvider certs.CertificatesProvider, ingresses []*ku
 				continue
 			}
 		}
-		if item, ok := model[certificateARN]; ok {
+		if item, ok := model[certificateARN+"/"+ingress.Scheme()]; ok {
 			item.ingresses = append(item.ingresses, ingress)
 		} else {
-			model[certificateARN] = &managedItem{ingresses: []*kubernetes.Ingress{ingress}}
+			model[certificateARN+"/"+ingress.Scheme()] = &managedItem{ingresses: []*kubernetes.Ingress{ingress}}
 		}
 	}
 	return model
@@ -209,7 +209,7 @@ func createStack(awsAdapter *aws.Adapter, item *managedItem) {
 	scheme := item.ingresses[0].Scheme()
 	log.Printf("creating %q stack for certificate %q / ingress %q", scheme, certificateARN, item.ingresses)
 
-	stackId, err := awsAdapter.CreateStack(certificateARN,scheme)
+	stackId, err := awsAdapter.CreateStack(certificateARN, scheme)
 	if err != nil {
 		if isAlreadyExistsError(err) {
 			item.stack, err = awsAdapter.GetStack(stackId)
@@ -228,7 +228,7 @@ func updateStack(awsAdapter *aws.Adapter, item *managedItem) {
 	scheme := item.ingresses[0].Scheme()
 	log.Printf("updating %q stack for certificate %q / ingress %q", scheme, certificateARN, item.ingresses)
 
-	stackId, err := awsAdapter.UpdateStack(certificateARN,scheme)
+	stackId, err := awsAdapter.UpdateStack(certificateARN, scheme)
 	if isNoUpdatesToBePerformedError(err) {
 		log.Printf("stack(%q) is already up to date", certificateARN)
 	} else if err != nil {


### PR DESCRIPTION
This groups ingresses by loadbalancer scheme. Without grouping them the controller would create a single ALB for two ingresses with different schemes assuming the certificate was the same.

Fixes #114 