### PR TITLE
Predictably select subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ On startup, the controller discovers the AWS resources required for the controll
     Lookup of the `kubernetes.io/cluster/<cluster-id>` tag of the Security Group matching the clusterID for the controller node and `kubernetes:application` matching the value `kube-ingress-aws-controller` or as fallback for `<v0.4.0`
     tag `aws:cloudformation:logical-id` matching the value `IngressLoadBalancerSecurityGroup` (only clusters created by CF).
 
+3. The Subnets
+
+    Subnets are discovered based on the VPC of the instance where the
+    controller is running. By default it will try to select all subnets of the
+    VPC but will limit the subnets to one per Availability Zone. If there are
+    many subnets within the VPC it's possible to tag the desired subnets with
+    the tags `kubernetes.io/role/elb` (for internet-facing ALBs) or
+    `kubernetes.io/role/internal-elb` (for internal ALBs). Subnets with these
+    tags will be favored when selecting subnets for the ALBs.
+    If there are two possible subnets for a single Availability Zone then the
+    first subnet, lexicographically sorted by ID, will be selected.
+
 ### Creating Load Balancers
 
 When the controller learns about new ingress resources, it uses the host specified in it to automatically determine

--- a/aws/adapter_test.go
+++ b/aws/adapter_test.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elbv2"
+)
+
+func TestFindLBSubnets(tt *testing.T) {
+	for _, test := range []struct {
+		name            string
+		subnets         []*subnetDetails
+		scheme          string
+		expectedSubnets []string
+	}{
+		{
+			name: "should find two public subnets for public LB",
+			subnets: []*subnetDetails{
+				{
+					availabilityZone: "a",
+					public:           true,
+					id:               "1",
+				},
+				{
+					availabilityZone: "b",
+					public:           true,
+					id:               "2",
+				},
+			},
+			scheme:          elbv2.LoadBalancerSchemeEnumInternetFacing,
+			expectedSubnets: []string{"1", "2"},
+		},
+		{
+			name: "should select first lexicographically subnet when two match a single zone",
+			subnets: []*subnetDetails{
+				{
+					availabilityZone: "a",
+					public:           true,
+					id:               "2",
+				},
+				{
+					availabilityZone: "a",
+					public:           true,
+					id:               "1",
+				},
+			},
+			scheme:          elbv2.LoadBalancerSchemeEnumInternetFacing,
+			expectedSubnets: []string{"1"},
+		},
+		{
+			name: "should not use internal subnets for public LB",
+			subnets: []*subnetDetails{
+				{
+					availabilityZone: "a",
+					public:           false,
+					id:               "2",
+				},
+			},
+			scheme:          elbv2.LoadBalancerSchemeEnumInternetFacing,
+			expectedSubnets: nil,
+		},
+		{
+			name: "should prefer tagged subnet",
+			subnets: []*subnetDetails{
+				{
+					availabilityZone: "a",
+					public:           true,
+					id:               "1",
+				},
+				{
+					availabilityZone: "a",
+					public:           true,
+					id:               "2",
+					tags: map[string]string{
+						elbRoleTagName: "",
+					},
+				},
+			},
+			scheme:          elbv2.LoadBalancerSchemeEnumInternetFacing,
+			expectedSubnets: []string{"2"},
+		},
+		{
+			name: "should prefer tagged subnet (internal)",
+			subnets: []*subnetDetails{
+				{
+					availabilityZone: "a",
+					public:           false,
+					id:               "1",
+				},
+				{
+					availabilityZone: "a",
+					public:           false,
+					id:               "2",
+					tags: map[string]string{
+						internalELBRoleTagName: "",
+					},
+				},
+			},
+			scheme:          elbv2.LoadBalancerSchemeEnumInternal,
+			expectedSubnets: []string{"2"},
+		},
+	} {
+		tt.Run(test.name, func(t *testing.T) {
+			a := &Adapter{
+				manifest: &manifest{
+					subnets: test.subnets,
+				},
+			}
+
+			subnets := a.FindLBSubnets(test.scheme)
+
+			if len(subnets) != len(test.expectedSubnets) {
+				t.Errorf("unexpected number of subnets %d, expected %d", len(subnets), len(test.expectedSubnets))
+			}
+
+			// sort subnets so it's simpler to compare.
+			sort.Strings(subnets)
+
+			for i, subnet := range subnets {
+				if subnet != test.expectedSubnets[i] {
+					t.Errorf("expected subnet %v, got %v", test.expectedSubnets[i], subnet)
+				}
+			}
+		})
+	}
+}

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -53,11 +53,10 @@ type subnetDetails struct {
 	availabilityZone string
 	tags             map[string]string
 	public           bool
-	elbRole          bool
 }
 
 func (sd *subnetDetails) String() string {
-	return fmt.Sprintf("%s (%s) @ %s (public: %t, elb: %t)", sd.Name(), sd.id, sd.availabilityZone, sd.public, sd.elbRole)
+	return fmt.Sprintf("%s (%s) @ %s (public: %t)", sd.Name(), sd.id, sd.availabilityZone, sd.public)
 }
 
 func (sd *subnetDetails) Name() string {
@@ -156,7 +155,6 @@ func getSubnets(svc ec2iface.EC2API, vpcID string) ([]*subnetDetails, error) {
 			availabilityZone: az,
 			public:           isPublic,
 			tags:             tags,
-			elbRole:          isELBSubnet(tags),
 		}
 	}
 	return ret, nil
@@ -232,13 +230,6 @@ func isSubnetPublic(rt []*ec2.RouteTable, subnetID string) (bool, error) {
 	}
 
 	return false, nil
-}
-
-// Returns true if the subnet tags indicate an ELB role.
-func isELBSubnet(tags map[string]string) bool {
-	_, external := tags[elbRoleTagName]
-	_, internal := tags[internalELBRoleTagName]
-	return external || internal
 }
 
 func findSecurityGroupWithClusterID(svc ec2iface.EC2API, clusterID string) (*securityGroupDetails, error) {

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -181,8 +181,8 @@ func TestGetSubnets(t *testing.T) {
 				), nil),
 			},
 			[]*subnetDetails{
-				{id: "foo1", availabilityZone: "baz1", public: true, tags: map[string]string{nameTag: "bar1", elbRoleTagName: ""}, elbRole: true},
-				{id: "foo2", availabilityZone: "baz2", public: true, tags: map[string]string{nameTag: "bar2"}, elbRole: false},
+				{id: "foo1", availabilityZone: "baz1", public: true, tags: map[string]string{nameTag: "bar1", elbRoleTagName: ""}},
+				{id: "foo2", availabilityZone: "baz2", public: true, tags: map[string]string{nameTag: "bar2"}},
 			},
 			false,
 		},

--- a/controller.go
+++ b/controller.go
@@ -11,6 +11,7 @@ import (
 
 	"io/ioutil"
 
+	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/zalando-incubator/kube-ingress-aws-controller/aws"
 	"github.com/zalando-incubator/kube-ingress-aws-controller/certs"
@@ -162,8 +163,8 @@ func main() {
 	log.Printf("\tinstance id: %s", awsAdapter.InstanceID())
 	log.Printf("\tauto scaling group name: %s", awsAdapter.AutoScalingGroupName())
 	log.Printf("\tsecurity group id: %s", awsAdapter.SecurityGroupID())
-	log.Printf("\tprivate subnet ids: %s", awsAdapter.PrivateSubnetIDs())
-	log.Printf("\tpublic subnet ids: %s", awsAdapter.PublicSubnetIDs())
+	log.Printf("\tinternal subnet ids: %s", awsAdapter.FindLBSubnets(elbv2.LoadBalancerSchemeEnumInternal))
+	log.Printf("\tpublic subnet ids: %s", awsAdapter.FindLBSubnets(elbv2.LoadBalancerSchemeEnumInternetFacing))
 
 	go serveMetrics(metricsAddress)
 	quitCH := make(chan struct{})


### PR DESCRIPTION
This changes the logic of selecting subnets for the ALB to match the logic used
by the kube-controller-manager when selecting subnets for ELBs used for
services of type LoadBalancer.

This solves several problems:

1. The controller will no longer try to create an ALB with multiple subnets of
the same AZ. (Fixes #108)

2. If only some subnets are tagged with the elb role the controller will favour
those with the tag but not limit the selection to only those with a tag.

3. Favour using internal subnets for ALBs with the scheme `internal`.

Fix #108