### PR TITLE
[WIP] Update stacks when needed

### DIFF
--- a/aws/cf_test.go
+++ b/aws/cf_test.go
@@ -106,7 +106,7 @@ func TestStackReadiness(t *testing.T) {
 		{"dummy-status", false},
 	} {
 		t.Run(ti.given, func(t *testing.T) {
-			got := isComplete(aws.String(ti.given))
+			got := isComplete(ti.given)
 			if ti.want != got {
 				t.Errorf("unexpected result. wanted %+v, got %+v", ti.want, got)
 			}
@@ -195,7 +195,7 @@ func TestConvertStackParameters(t *testing.T) {
 
 }
 
-func TestFindingManagedStacks(t *testing.T) {
+func TestFindManagedStacks(t *testing.T) {
 	for _, ti := range []struct {
 		name    string
 		given   cfMockOutputs
@@ -203,13 +203,14 @@ func TestFindingManagedStacks(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			"successful-call",
-			cfMockOutputs{
+			name: "successful-call",
+			given: cfMockOutputs{
 				describeStackPages: R(nil, nil),
 				describeStacks: R(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
 						{
-							StackName: aws.String("managed-stack-not-ready"),
+							StackName:   aws.String("managed-stack-not-ready"),
+							StackStatus: aws.String(cloudformation.StackStatusUpdateInProgress),
 							Tags: []*cloudformation.Tag{
 								cfTag(kubernetesCreatorTag, kubernetesCreatorValue),
 								cfTag(clusterIDTagPrefix+"test-cluster", resourceLifecycleOwned),
@@ -234,7 +235,8 @@ func TestFindingManagedStacks(t *testing.T) {
 							},
 						},
 						{
-							StackName: aws.String("managed-stack-not-ready"),
+							StackName:   aws.String("managed-stack-not-ready"),
+							StackStatus: aws.String(cloudformation.StackStatusUpdateInProgress),
 							Tags: []*cloudformation.Tag{
 								cfTag(kubernetesCreatorTag, kubernetesCreatorValue),
 								cfTag(clusterIDTagPrefix+"test-cluster", resourceLifecycleOwned),
@@ -262,7 +264,19 @@ func TestFindingManagedStacks(t *testing.T) {
 					},
 				}, nil),
 			},
-			[]*Stack{
+			want: []*Stack{
+				{
+					name:           "managed-stack-not-ready",
+					dnsName:        "example-notready.com",
+					certificateARN: "cert-arn",
+					targetGroupARN: "tg-arn",
+					tags: map[string]string{
+						kubernetesCreatorTag:                kubernetesCreatorValue,
+						clusterIDTagPrefix + "test-cluster": resourceLifecycleOwned,
+						certificateARNTag:                   "cert-arn",
+					},
+					status: cloudformation.StackStatusUpdateInProgress,
+				},
 				{
 					name:           "managed-stack",
 					dnsName:        "example.com",
@@ -273,13 +287,22 @@ func TestFindingManagedStacks(t *testing.T) {
 						clusterIDTagPrefix + "test-cluster": resourceLifecycleOwned,
 						certificateARNTag:                   "cert-arn",
 					},
+					status: cloudformation.StackStatusCreateComplete,
+				},
+				{
+					name: "managed-stack-not-ready",
+					tags: map[string]string{
+						kubernetesCreatorTag:                kubernetesCreatorValue,
+						clusterIDTagPrefix + "test-cluster": resourceLifecycleOwned,
+					},
+					status: cloudformation.StackStatusUpdateInProgress,
 				},
 			},
-			false,
+			wantErr: false,
 		},
 		{
-			"no-ready-stacks",
-			cfMockOutputs{
+			name: "no-ready-stacks",
+			given: cfMockOutputs{
 				describeStackPages: R(nil, nil),
 				describeStacks: R(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
@@ -310,8 +333,29 @@ func TestFindingManagedStacks(t *testing.T) {
 					},
 				}, nil),
 			},
-			[]*Stack{},
-			true,
+			want: []*Stack{
+				{
+					name:           "managed-stack-not-ready",
+					dnsName:        "example-notready.com",
+					targetGroupARN: "tg-arn",
+					tags: map[string]string{
+						kubernetesCreatorTag:                kubernetesCreatorValue,
+						clusterIDTagPrefix + "test-cluster": resourceLifecycleOwned,
+					},
+					status: cloudformation.StackStatusReviewInProgress,
+				},
+				{
+					name:           "managed-stack",
+					dnsName:        "example.com",
+					targetGroupARN: "tg-arn",
+					tags: map[string]string{
+						kubernetesCreatorTag:                kubernetesCreatorValue,
+						clusterIDTagPrefix + "test-cluster": resourceLifecycleOwned,
+					},
+					status: cloudformation.StackStatusRollbackComplete,
+				},
+			},
+			wantErr: false,
 		},
 		{
 			"failed-paging",
@@ -343,18 +387,94 @@ func TestFindingManagedStacks(t *testing.T) {
 					t.Errorf("unexpected result. wanted %+v, got %+v", ti.want, got)
 				}
 			}
+		})
+	}
+}
 
+func TestGetStack(t *testing.T) {
+	for _, ti := range []struct {
+		name    string
+		given   cfMockOutputs
+		want    *Stack
+		wantErr bool
+	}{
+		{
+			name: "successful-call",
+			given: cfMockOutputs{
+				describeStackPages: R(nil, nil),
+				describeStacks: R(&cloudformation.DescribeStacksOutput{
+					Stacks: []*cloudformation.Stack{
+						{
+							StackName:   aws.String("managed-stack"),
+							StackStatus: aws.String(cloudformation.StackStatusCreateComplete),
+							Tags: []*cloudformation.Tag{
+								cfTag(kubernetesCreatorTag, kubernetesCreatorValue),
+								cfTag(clusterIDTagPrefix+"test-cluster", resourceLifecycleOwned),
+								cfTag(certificateARNTag, "cert-arn"),
+							},
+							Outputs: []*cloudformation.Output{
+								{OutputKey: aws.String(outputLoadBalancerDNSName), OutputValue: aws.String("example.com")},
+								{OutputKey: aws.String(outputTargetGroupARN), OutputValue: aws.String("tg-arn")},
+							},
+						},
+					},
+				}, nil),
+			},
+			want: &Stack{
+				name:           "managed-stack",
+				dnsName:        "example.com",
+				certificateARN: "cert-arn",
+				targetGroupARN: "tg-arn",
+				tags: map[string]string{
+					kubernetesCreatorTag:                kubernetesCreatorValue,
+					clusterIDTagPrefix + "test-cluster": resourceLifecycleOwned,
+					certificateARNTag:                   "cert-arn",
+				},
+				status: cloudformation.StackStatusCreateComplete,
+			},
+			wantErr: false,
+		},
+		{
+			name: "no-ready-stacks",
+			given: cfMockOutputs{
+				describeStackPages: R(nil, nil),
+				describeStacks: R(&cloudformation.DescribeStacksOutput{
+					Stacks: []*cloudformation.Stack{},
+				}, nil),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			"failed-paging",
+			cfMockOutputs{
+				describeStackPages: R(nil, dummyErr),
+				describeStacks:     R(&cloudformation.DescribeStacksOutput{}, nil),
+			},
+			nil,
+			true,
+		},
+		{
+			"failed-describe-page",
+			cfMockOutputs{
+				describeStacks: R(nil, dummyErr),
+			},
+			nil,
+			true,
+		},
+	} {
+		t.Run(ti.name, func(t *testing.T) {
+			c := &mockCloudFormationClient{outputs: ti.given}
 			s, err := getStack(c, "dontcare")
 			if err != nil {
 				if !ti.wantErr {
 					t.Error("unexpected error", err)
 				}
 			} else {
-				if !reflect.DeepEqual(ti.want[0], s) {
-					t.Errorf("unexpected result. wanted %+v, got %+v", ti.want[0], got)
+				if !reflect.DeepEqual(ti.want, s) {
+					t.Errorf("unexpected result. wanted %+v, got %+v", ti.want, s)
 				}
 			}
-
 		})
 	}
 }
@@ -477,4 +597,16 @@ func TestDeleteTime(t *testing.T) {
 		})
 	}
 
+}
+
+func TestIsComplete(t *testing.T) {
+	var s *Stack
+	if s.IsComplete() {
+		t.Errorf("expected the stack to not be complete")
+	}
+
+	s = &Stack{status: cloudformation.StackStatusCreateComplete}
+	if !s.IsComplete() {
+		t.Errorf("expected the stack to be complete")
+	}
 }

--- a/controller.go
+++ b/controller.go
@@ -28,7 +28,6 @@ var (
 	healthCheckPort     uint
 	healthcheckInterval time.Duration
 	metricsAddress      string
-	updateStackInterval time.Duration
 )
 
 func loadSettings() error {
@@ -37,7 +36,6 @@ func loadSettings() error {
 		"server base url. If empty will try to use the configuration from the running cluster, else it will use InsecureConfig, that does not use encryption or authentication (use case to develop with kubectl proxy).")
 	flag.DurationVar(&pollingInterval, "polling-interval", 30*time.Second, "sets the polling interval for "+
 		"ingress resources. The flag accepts a value acceptable to time.ParseDuration")
-	flag.DurationVar(&updateStackInterval, "update-stack-interval", 1*time.Hour, "sets the interval for update AWS ALB stack resources, which can fix migrations, if you add for example one subnet to your VPC your ALB has not interface in that. An update stack will add these interfaces automatically. The flag accepts a value acceptable to time.ParseDuration")
 	flag.StringVar(&cfCustomTemplate, "cf-custom-template", "",
 		"filename for a custom cloud formation template to use instead of the built in")
 	flag.DurationVar(&creationTimeout, "creation-timeout", aws.DefaultCreationTimeout,
@@ -62,9 +60,6 @@ func loadSettings() error {
 	}
 
 	if err := loadDurationFromEnv("POLLING_INTERVAL", &pollingInterval); err != nil {
-		return err
-	}
-	if err := loadDurationFromEnv("UPDATE_STACK_INTERVAL", &updateStackInterval); err != nil {
 		return err
 	}
 
@@ -168,7 +163,7 @@ func main() {
 
 	go serveMetrics(metricsAddress)
 	quitCH := make(chan struct{})
-	go startPolling(quitCH, certificatesProvider, awsAdapter, kubeAdapter, pollingInterval, updateStackInterval)
+	go startPolling(quitCH, certificatesProvider, awsAdapter, kubeAdapter, pollingInterval)
 	<-quitCH
 
 	log.Printf("terminating %s", os.Args[0])


### PR DESCRIPTION
This PR aims to address two issues.

1. Stacks were scheduled to update by sending them to a channel and having a separate go routine triggering the updates every hour (by default). Instead of waiting one hour to do the update we can just check if an update is needed and schedule it right away. This is important for the SNI support (#111) as we want to add new certificates to existing ALBs and not wait an hour for it to propagate.

2. `FindManagedStacks` was only returning stacks in a completed state, this resulted in more stacks being created in cases where a stack update was triggered and some stacks were not returned from the `FindManagedStacks` call because they were in an update state. Instead it just returns all stacks and checks the state when deciding if they should be updated or not. I.e. stacks already being updated will not be updated again until they reach a complete state first.

I marked this **WIP** because I need to validate that this works correctly, but initial review is welcome :)