### PR TITLE
Always tests against latest go stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 language: go
 
 go:
-- 1.9
+- 1.x
 - tip
 
 matrix:


### PR DESCRIPTION
This is similar to what we do for the Dockerfile build. (we always use the latest stable version of go automatically).