### PR TITLE
Remove obsolete Target Groups from ASGs

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -277,7 +277,7 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 	}
 	for _, asg := range a.autoScalingGroups {
 		// This call is idempotent and safe to execute every time
-		if err := attachTargetGroupsToAutoScalingGroup(a.autoscaling, targetGroupARNs, asg.name); err != nil {
+		if err := updateTargetGroupsForAutoScalingGroup(a.autoscaling, targetGroupARNs, asg.name); err != nil {
 			log.Printf("UpdateTargetGroupsAndAutoScalingGroups() failed to attach target groups to ASG: %v", err)
 		}
 	}
@@ -361,7 +361,7 @@ func (a *Adapter) GetStack(stackID string) (*Stack, error) {
 // DeleteStack deletes the CloudFormation stack with the given name
 func (a *Adapter) DeleteStack(stack *Stack) error {
 	for _, asg := range a.autoScalingGroups {
-		if err := detachTargetGroupFromAutoScalingGroup(a.autoscaling, stack.TargetGroupARN(), asg.name); err != nil {
+		if err := detachTargetGroupsFromAutoScalingGroup(a.autoscaling, []string{stack.TargetGroupARN()}, asg.name); err != nil {
 			return fmt.Errorf("DeleteStack failed to detach: %v", err)
 		}
 	}

--- a/aws/asgmock_test.go
+++ b/aws/asgmock_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 type autoscalingMockOutputs struct {
-	describeAutoScalingGroups      *apiResponse
-	attachLoadBalancerTargetGroups *apiResponse
-	detachLoadBalancerTargetGroups *apiResponse
+	describeAutoScalingGroups        *apiResponse
+	attachLoadBalancerTargetGroups   *apiResponse
+	detachLoadBalancerTargetGroups   *apiResponse
+	describeLoadBalancerTargetGroups *apiResponse
 }
 
 type mockAutoScalingClient struct {
@@ -22,6 +23,13 @@ func (m *mockAutoScalingClient) DescribeAutoScalingGroups(*autoscaling.DescribeA
 		return out, m.outputs.describeAutoScalingGroups.err
 	}
 	return nil, m.outputs.describeAutoScalingGroups.err
+}
+
+func (m *mockAutoScalingClient) DescribeLoadBalancerTargetGroups(*autoscaling.DescribeLoadBalancerTargetGroupsInput) (*autoscaling.DescribeLoadBalancerTargetGroupsOutput, error) {
+	if out, ok := m.outputs.describeLoadBalancerTargetGroups.response.(*autoscaling.DescribeLoadBalancerTargetGroupsOutput); ok {
+		return out, m.outputs.describeLoadBalancerTargetGroups.err
+	}
+	return nil, m.outputs.describeLoadBalancerTargetGroups.err
 }
 
 func (m *mockAutoScalingClient) AttachLoadBalancerTargetGroups(*autoscaling.AttachLoadBalancerTargetGroupsInput) (*autoscaling.AttachLoadBalancerTargetGroupsOutput, error) {


### PR DESCRIPTION
This ensures that obsolete Target Groups gets removed from the ASGs.

Fix #126