### PR TITLE
Make it possible to get a unique ALB for a single ingress resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,11 @@ spec:
 
 You can only select from `internet-facing` (default) and `internal` options.
 
-By default the ingress-controller will aggregate all ingresses under a single
-Application Load Balancer (unless running with `-disable-sni-support`). If you
-like to provision an Application Load Balancer that is unique for an ingress
-you can use the annotation `zalando.org/aws-load-balancer-shared: "false"`.
+By default the ingress-controller will aggregate all ingresses under as few
+Application Load Balancers as possible (unless running with
+`-disable-sni-support`). If you like to provision an Application Load Balancer
+that is unique for an ingress you can use the annotation
+`zalando.org/aws-load-balancer-shared: "false"`.
 
 The new Application Load Balancers have a custom tag marking them as *managed* load balancers to differentiate them
 from other load balancers. The tag looks like this:

--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ spec:
 
 You can only select from `internet-facing` (default) and `internal` options.
 
+By default the ingress-controller will aggregate all ingresses under a single
+Application Load Balancer (unless running with `-disable-sni-support`). If you
+like to provision an Application Load Balancer that is unique for an ingress
+you can use the annotation `zalando.org/aws-load-balancer-shared: "false"`.
+
 The new Application Load Balancers have a custom tag marking them as *managed* load balancers to differentiate them
 from other load balancers. The tag looks like this:
 

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -304,7 +304,7 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 // All the required resources (listeners and target group) are created in a
 // transactional fashion.
 // Failure to create the stack causes it to be deleted automatically.
-func (a *Adapter) CreateStack(certificateARNs []string, scheme string) (string, error) {
+func (a *Adapter) CreateStack(certificateARNs []string, scheme, owner string) (string, error) {
 	certARNs := make(map[string]time.Time, len(certificateARNs))
 	for _, arn := range certificateARNs {
 		certARNs[arn] = time.Time{}
@@ -313,6 +313,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme string) (string, 
 	spec := &stackSpec{
 		name:            a.stackName(),
 		scheme:          scheme,
+		ownerIngress:    owner,
 		certificateARNs: certARNs,
 		securityGroupID: a.SecurityGroupID(),
 		subnets:         a.FindLBSubnets(scheme),

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -143,6 +143,12 @@ func newIngressFromKube(kubeIngress *ingress) *Ingress {
 }
 
 func newIngressForKube(i *Ingress) *ingress {
+	shared := "true"
+
+	if !i.shared {
+		shared = "false"
+	}
+
 	return &ingress{
 		Metadata: ingressItemMetadata{
 			Namespace: i.namespace,
@@ -150,6 +156,7 @@ func newIngressForKube(i *Ingress) *ingress {
 			Annotations: map[string]interface{}{
 				ingressCertificateARNAnnotation: i.certificateARN,
 				ingressSchemeAnnotation:         i.scheme,
+				ingressSharedAnnotation:         shared,
 			},
 		},
 		Status: ingressStatus{

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -39,6 +39,7 @@ type Ingress struct {
 	hostName       string
 	scheme         string
 	certHostname   string
+	shared         bool
 }
 
 // CertificateARN returns the AWS certificate (IAM or ACM) ARN found in the ingress resource metadata.
@@ -79,6 +80,21 @@ func (i *Ingress) SetScheme(scheme string) {
 	i.scheme = scheme
 }
 
+// Shared return true if the ingress can share ALB with other ingresses.
+func (i *Ingress) Shared() bool {
+	return i.shared
+}
+
+// Name returns the ingress name.
+func (i *Ingress) Name() string {
+	return i.name
+}
+
+// Namespace returns the ingress namespace.
+func (i *Ingress) Namespace() string {
+	return i.namespace
+}
+
 func newIngressFromKube(kubeIngress *ingress) *Ingress {
 	var host, certHostname, scheme string
 	for _, ingressLoadBalancer := range kubeIngress.Status.LoadBalancer.Ingress {
@@ -108,6 +124,13 @@ func newIngressFromKube(kubeIngress *ingress) *Ingress {
 		certHostname = certDomain
 	}
 
+	shared := true
+
+	sharedValue := kubeIngress.getAnnotationsString(ingressSharedAnnotation, "")
+	if sharedValue == "false" {
+		shared = false
+	}
+
 	return &Ingress{
 		certificateARN: kubeIngress.getAnnotationsString(ingressCertificateARNAnnotation, ""),
 		namespace:      kubeIngress.Metadata.Namespace,
@@ -115,6 +138,7 @@ func newIngressFromKube(kubeIngress *ingress) *Ingress {
 		hostName:       host,
 		scheme:         scheme,
 		certHostname:   certHostname,
+		shared:         shared,
 	}
 }
 

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -18,6 +18,7 @@ func TestMappingRoundtrip(t *testing.T) {
 		hostName:       "bar",
 		scheme:         "internal",
 		certificateARN: "zbr",
+		shared:         true,
 	}
 
 	kubeMeta := ingressItemMetadata{

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -11,58 +11,97 @@ import (
 	"testing"
 )
 
-func TestMappingRoundtrip(t *testing.T) {
-	i := &Ingress{
-		namespace:      "default",
-		name:           "foo",
-		hostName:       "bar",
-		scheme:         "internal",
-		certificateARN: "zbr",
-		shared:         true,
-	}
-
-	kubeMeta := ingressItemMetadata{
-		Namespace: "default",
-		Name:      "foo",
-		Annotations: map[string]interface{}{
-			ingressCertificateARNAnnotation: "zbr",
-			ingressSchemeAnnotation:         "internal",
-		},
-	}
-	kubeStatus := ingressStatus{
-		LoadBalancer: ingressLoadBalancerStatus{
-			Ingress: []ingressLoadBalancer{
-				{Hostname: ""},
-				{Hostname: "bar"},
+func TestMappingRoundtrip(tt *testing.T) {
+	for _, tc := range []struct {
+		msg         string
+		ingress     *Ingress
+		kubeIngress *ingress
+	}{
+		{
+			msg: "test parsing a simple ingress object",
+			ingress: &Ingress{
+				namespace:      "default",
+				name:           "foo",
+				hostName:       "bar",
+				scheme:         "internal",
+				certificateARN: "zbr",
+				shared:         true,
+			},
+			kubeIngress: &ingress{
+				Metadata: ingressItemMetadata{
+					Namespace: "default",
+					Name:      "foo",
+					Annotations: map[string]interface{}{
+						ingressCertificateARNAnnotation: "zbr",
+						ingressSchemeAnnotation:         "internal",
+						ingressSharedAnnotation:         "true",
+					},
+				},
+				Status: ingressStatus{
+					LoadBalancer: ingressLoadBalancerStatus{
+						Ingress: []ingressLoadBalancer{
+							{Hostname: ""},
+							{Hostname: "bar"},
+						},
+					},
+				},
 			},
 		},
-	}
-	kubeIngress := &ingress{
-		Metadata: kubeMeta,
-		Status:   kubeStatus,
-	}
+		{
+			msg: "test parsing an ingress object with shared=false annotation",
+			ingress: &Ingress{
+				namespace:      "default",
+				name:           "foo",
+				hostName:       "bar",
+				scheme:         "internal",
+				certificateARN: "zbr",
+				shared:         false,
+			},
+			kubeIngress: &ingress{
+				Metadata: ingressItemMetadata{
+					Namespace: "default",
+					Name:      "foo",
+					Annotations: map[string]interface{}{
+						ingressCertificateARNAnnotation: "zbr",
+						ingressSchemeAnnotation:         "internal",
+						ingressSharedAnnotation:         "false",
+					},
+				},
+				Status: ingressStatus{
+					LoadBalancer: ingressLoadBalancerStatus{
+						Ingress: []ingressLoadBalancer{
+							{Hostname: ""},
+							{Hostname: "bar"},
+						},
+					},
+				},
+			},
+		},
+	} {
+		tt.Run(tc.msg, func(t *testing.T) {
+			got := newIngressFromKube(tc.kubeIngress)
+			if !reflect.DeepEqual(tc.ingress, got) {
+				t.Errorf("mapping from kubernetes ingress to adapter failed. wanted %v, got %v", tc.ingress, got)
+			}
+			if got.CertificateARN() != tc.kubeIngress.Metadata.Annotations[ingressCertificateARNAnnotation] {
+				t.Error("wrong value from CertificateARN()")
+			}
+			if got.Scheme() != tc.kubeIngress.Metadata.Annotations[ingressSchemeAnnotation] {
+				t.Error("wrong value from Scheme()")
+			}
+			if got.Hostname() != tc.kubeIngress.Status.LoadBalancer.Ingress[1].Hostname {
+				t.Error("wrong value from Hostname()")
+			}
+			if got.String() != fmt.Sprintf("%s/%s", tc.ingress.namespace, tc.ingress.name) {
+				t.Error("wrong value from String()")
+			}
 
-	got := newIngressFromKube(kubeIngress)
-	if !reflect.DeepEqual(i, got) {
-		t.Errorf("mapping from kubernetes ingress to adapter failed. wanted %v, got %v", i, got)
-	}
-	if got.CertificateARN() != kubeIngress.Metadata.Annotations[ingressCertificateARNAnnotation] {
-		t.Error("wrong value from CertificateARN()")
-	}
-	if got.Scheme() != kubeIngress.Metadata.Annotations[ingressSchemeAnnotation] {
-		t.Error("wrong value from Scheme()")
-	}
-	if got.Hostname() != kubeIngress.Status.LoadBalancer.Ingress[1].Hostname {
-		t.Error("wrong value from Hostname()")
-	}
-	if got.String() != "default/foo" {
-		t.Error("wrong value from String()")
-	}
-
-	kubeIngress.Status.LoadBalancer.Ingress = kubeIngress.Status.LoadBalancer.Ingress[1:]
-	gotKube := newIngressForKube(got)
-	if !reflect.DeepEqual(kubeIngress, gotKube) {
-		t.Errorf("mapping from adapter to kubernetes ingress failed. wanted %v, got %v", kubeIngress, gotKube)
+			tc.kubeIngress.Status.LoadBalancer.Ingress = tc.kubeIngress.Status.LoadBalancer.Ingress[1:]
+			gotKube := newIngressForKube(got)
+			if !reflect.DeepEqual(tc.kubeIngress, gotKube) {
+				t.Errorf("mapping from adapter to kubernetes ingress failed. wanted %v, got %v", tc.kubeIngress, gotKube)
+			}
+		})
 	}
 }
 

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -64,6 +64,7 @@ const (
 	ingressCertificateARNAnnotation    = "zalando.org/aws-load-balancer-ssl-cert"
 	ingressCertificateDomainAnnotation = "zalando.org/aws-load-balancer-ssl-cert-domain"
 	ingressSchemeAnnotation            = "zalando.org/aws-load-balancer-scheme"
+	ingressSharedAnnotation            = "zalando.org/aws-load-balancer-shared"
 )
 
 func (i *ingress) getAnnotationsString(key string, defaultValue string) string {


### PR DESCRIPTION
This adds an annotation `zalando.org/aws-load-balancer-shared: "false"` which, when set will make sure to provision an ALB that is unique for a single ingress resources. This is useful if a single application in the cluster has clients which doesn't support SNI or if it's getting so much traffic that it should not share the ALB with other applications.

It works by having a `ingress:owner=<namespace>/<ingress-name>` tag on the stacks which are reserved for a single ingress. If the annotation is later removed from the ingress the stacks will be re-aggregated.

Fix #129