### PR TITLE
Add flag for enabling stack termination protection on ALB stacks

### DIFF
--- a/aws/cf.go
+++ b/aws/cf.go
@@ -270,8 +270,18 @@ func cfTag(key, value string) *cloudformation.Tag {
 }
 
 func deleteStack(svc cloudformationiface.CloudFormationAPI, stackName string) error {
+	termParams := &cloudformation.UpdateTerminationProtectionInput{
+		StackName:                   aws.String(stackName),
+		EnableTerminationProtection: aws.Bool(false),
+	}
+
+	_, err := svc.UpdateTerminationProtection(termParams)
+	if err != nil {
+		return err
+	}
+
 	params := &cloudformation.DeleteStackInput{StackName: aws.String(stackName)}
-	_, err := svc.DeleteStack(params)
+	_, err = svc.DeleteStack(params)
 	return err
 }
 

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -130,17 +130,18 @@ const (
 )
 
 type stackSpec struct {
-	name             string
-	scheme           string
-	ownerIngress     string
-	subnets          []string
-	certificateARNs  map[string]time.Time
-	securityGroupID  string
-	clusterID        string
-	vpcID            string
-	healthCheck      *healthCheck
-	timeoutInMinutes uint
-	customTemplate   string
+	name                       string
+	scheme                     string
+	ownerIngress               string
+	subnets                    []string
+	certificateARNs            map[string]time.Time
+	securityGroupID            string
+	clusterID                  string
+	vpcID                      string
+	healthCheck                *healthCheck
+	timeoutInMinutes           uint
+	customTemplate             string
+	stackTerminationProtection bool
 }
 
 type healthCheck struct {
@@ -168,8 +169,9 @@ func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfTag(kubernetesCreatorTag, kubernetesCreatorValue),
 			cfTag(clusterIDTagPrefix+spec.clusterID, resourceLifecycleOwned),
 		},
-		TemplateBody:     aws.String(template),
-		TimeoutInMinutes: aws.Int64(int64(spec.timeoutInMinutes)),
+		TemplateBody:                aws.String(template),
+		TimeoutInMinutes:            aws.Int64(int64(spec.timeoutInMinutes)),
+		EnableTerminationProtection: aws.Bool(spec.stackTerminationProtection),
 	}
 
 	for certARN, ttl := range spec.certificateARNs {
@@ -231,6 +233,18 @@ func updateStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 
 	if spec.ownerIngress != "" {
 		params.Tags = append(params.Tags, cfTag(ingressOwnerTag, spec.ownerIngress))
+	}
+
+	if spec.stackTerminationProtection {
+		params := &cloudformation.UpdateTerminationProtectionInput{
+			StackName:                   aws.String(spec.name),
+			EnableTerminationProtection: aws.Bool(spec.stackTerminationProtection),
+		}
+
+		_, err := svc.UpdateTerminationProtection(params)
+		if err != nil {
+			return spec.name, err
+		}
 	}
 
 	resp, err := svc.UpdateStack(params)

--- a/aws/cf_test.go
+++ b/aws/cf_test.go
@@ -73,13 +73,19 @@ func TestDeleteStack(t *testing.T) {
 		{
 			"delete-existing-stack",
 			stackSpec{name: "existing-stack-id"},
-			cfMockOutputs{deleteStack: R(mockDeleteStackOutput("existing-stack-id"), nil)},
+			cfMockOutputs{
+				deleteStack:                 R(mockDeleteStackOutput("existing-stack-id"), nil),
+				updateTerminationProtection: R(nil, nil),
+			},
 			false,
 		},
 		{
 			"delete-non-existing-stack",
 			stackSpec{name: "non-existing-stack-id"},
-			cfMockOutputs{deleteStack: R(mockDeleteStackOutput("existing-stack-id"), nil)},
+			cfMockOutputs{
+				deleteStack:                 R(mockDeleteStackOutput("existing-stack-id"), nil),
+				updateTerminationProtection: R(nil, nil),
+			},
 			false,
 		},
 	} {

--- a/aws/cfmock_test.go
+++ b/aws/cfmock_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 type cfMockOutputs struct {
-	describeStackPages *apiResponse
-	describeStacks     *apiResponse
-	createStack        *apiResponse
-	deleteStack        *apiResponse
+	describeStackPages          *apiResponse
+	describeStacks              *apiResponse
+	createStack                 *apiResponse
+	deleteStack                 *apiResponse
+	updateTerminationProtection *apiResponse
 }
 
 type mockCloudFormationClient struct {
@@ -65,4 +66,11 @@ func (m *mockCloudFormationClient) DeleteStack(params *cloudformation.DeleteStac
 
 func mockDeleteStackOutput(stackId string) *cloudformation.DeleteStackOutput {
 	return &cloudformation.DeleteStackOutput{}
+}
+
+func (m *mockCloudFormationClient) UpdateTerminationProtection(params *cloudformation.UpdateTerminationProtectionInput) (*cloudformation.UpdateTerminationProtectionOutput, error) {
+	if out, ok := m.outputs.updateTerminationProtection.response.(*cloudformation.UpdateTerminationProtectionOutput); ok {
+		return out, m.outputs.updateTerminationProtection.err
+	}
+	return nil, m.outputs.updateTerminationProtection.err
 }

--- a/controller.go
+++ b/controller.go
@@ -24,17 +24,18 @@ const (
 )
 
 var (
-	apiServerBaseURL    string
-	pollingInterval     time.Duration
-	cfCustomTemplate    string
-	creationTimeout     time.Duration
-	certPollingInterval time.Duration
-	healthCheckPath     string
-	healthCheckPort     uint
-	healthcheckInterval time.Duration
-	metricsAddress      string
-	disableSNISupport   bool
-	certTTL             time.Duration
+	apiServerBaseURL           string
+	pollingInterval            time.Duration
+	cfCustomTemplate           string
+	creationTimeout            time.Duration
+	certPollingInterval        time.Duration
+	healthCheckPath            string
+	healthCheckPort            uint
+	healthcheckInterval        time.Duration
+	metricsAddress             string
+	disableSNISupport          bool
+	certTTL                    time.Duration
+	stackTerminationProtection bool
 )
 
 func loadSettings() error {
@@ -52,6 +53,7 @@ func loadSettings() error {
 		"sets the polling interval for the certificates cache refresh. The flag accepts a value "+
 			"acceptable to time.ParseDuration")
 	flag.BoolVar(&disableSNISupport, "disable-sni-support", defaultDisableSNISupport, "disables SNI support limiting the number of certificates per ALB to 1.")
+	flag.BoolVar(&stackTerminationProtection, "stack-termination-protection", false, "enables stack termination protection for the stacks managed by the controller.")
 	flag.DurationVar(&certTTL, "cert-ttl-timeout", defaultCertTTL,
 		"sets the timeout of how long a certificate is kept on an old ALB to be decommissioned.")
 	flag.StringVar(&healthCheckPath, "health-check-path", aws.DefaultHealthCheckPath,
@@ -137,7 +139,8 @@ func main() {
 		WithHealthCheckPath(healthCheckPath).
 		WithHealthCheckPort(healthCheckPort).
 		WithCreationTimeout(creationTimeout).
-		WithCustomTemplate(cfCustomTemplate)
+		WithCustomTemplate(cfCustomTemplate).
+		WithStackTerminationProtection(stackTerminationProtection)
 
 	certificatesProvider, err := certs.NewCachingProvider(
 		certPollingInterval,

--- a/deploy/requirements.md
+++ b/deploy/requirements.md
@@ -224,6 +224,11 @@ Please also note that the worker nodes will need the right permission to describ
     "Effect": "Allow"
 },
 {
+    "Action": "cloudformation:Update*",
+    "Resource": "*",
+    "Effect": "Allow"
+},
+{
     "Action": "cloudformation:Delete*",
     "Resource": "*",
     "Effect": "Allow"

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 193d96396c6fb12cba493b6c70116f4f428c9c1efbba8e18c3c7152f9c29213b
-updated: 2018-02-15T01:11:31.164349405+01:00
+hash: daa66bbd8c5cb55619791c64a264055de9a8ed87d29f4274d4de0170f033399d
+updated: 2018-02-27T22:41:20.013074127+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: github.com/aws/aws-sdk-go
-  version: 96358b8282b1a3aa66836d2f2fe66216cc419668
+  version: ce48e67ca697079662aee65a13202f37a185962b
   subpackages:
   - aws
   - aws/awserr
@@ -22,6 +22,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/sdkrand
   - internal/shareddefaults
   - private/protocol
   - private/protocol/ec2query

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/zalando-incubator/kube-ingress-aws-controller
 import:
 - package: github.com/aws/aws-sdk-go
-  version: ~1.8.31
+  version: ~1.13.6
   subpackages:
   - aws
   - aws/awserr


### PR DESCRIPTION
Adds flag for enabling stack termination protection on ALB stacks.

https://aws.amazon.com/about-aws/whats-new/2017/09/aws-cloudformation-provides-stack-termination-protection/

This is to have a bit more protection against users terminating infrastructure stacks in the AWS console.