### PR TITLE
Add support for finding multiple certificates per ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ On startup, the controller discovers the AWS resources required for the controll
 
 ### Creating Load Balancers
 
-When the controller learns about new ingress resources, it uses the host specified in it to automatically determine
-the most specific, valid certificate to use. The certificate has to be valid for at least 7 days. An example ingress:
+When the controller learns about new ingress resources, it uses the hosts specified in it to automatically determine
+the most specific, valid certificates to use. The certificates has to be valid for at least 7 days. An example ingress:
 
 ```yaml
 apiVersion: extensions/v1beta1
@@ -169,12 +169,13 @@ spec:
 ```
 
 The Application Load Balancer created by the controller will have both an HTTP listener and an HTTPS listener. The
-latter will use the automatically selected certificate.
+latter will use the automatically selected certificates.
 
 Alternatively, you can specify a domain used for automatically selecting a
 certificate with an annotation like the one shown below. This is useful if you
-have multiple hosts rules defined and want to make sure to select a certificate
-for the right hostname.
+have multiple host rules defined and want to only select one certificate for a
+specific hostname. Generally it's better to let the controller select all
+matching certificates.
 
 ```yaml
 apiVersion: extensions/v1beta1

--- a/certs/matching.go
+++ b/certs/matching.go
@@ -16,6 +16,27 @@ const (
 // ErrNoMatchingCertificateFound is used if there is no matching ACM certificate found
 var ErrNoMatchingCertificateFound = errors.New("no matching certificate found")
 
+// FindBestMatchingCertificates uses a suffix search, best match operation, in
+// order to find the best matching certificates for a given hostnames.
+func FindBestMatchingCertificates(certs []*CertificateSummary, hostnames []string) ([]*CertificateSummary, error) {
+	certsMap := make(map[string]*CertificateSummary)
+
+	for _, hostname := range hostnames {
+		certSummary, err := FindBestMatchingCertificate(certs, hostname)
+		if err != nil {
+			return nil, err
+		}
+		certsMap[certSummary.ID()] = certSummary
+	}
+
+	matchedCerts := make([]*CertificateSummary, 0, len(certsMap))
+	for _, cert := range certsMap {
+		matchedCerts = append(matchedCerts, cert)
+	}
+
+	return matchedCerts, nil
+}
+
 // FindBestMatchingCertificate uses a suffix search, best match operation, in order to find the best matching
 // certificate for a given hostname.
 func FindBestMatchingCertificate(certs []*CertificateSummary, hostname string) (*CertificateSummary, error) {

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -121,8 +121,8 @@ func TestCertDomainAnnotation(t *testing.T) {
 	}
 
 	got := newIngressFromKube(kubeIngress)
-	if got.CertHostname() != certDomain {
-		t.Errorf("expected cert hostname %s, got %s", certDomain, got.CertHostname())
+	if got.CertHostnames()[0] != certDomain {
+		t.Errorf("expected cert hostname %s, got %s", certDomain, got.CertHostnames()[0])
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -73,7 +73,7 @@ func (item *managedItem) certsEqual() bool {
 // The function returns true when the ingress was successfully added. The
 // adding can fail in case the managed item reached its limit of ingress
 // certificates (25 max) or if the scheme doesn't match.
-func (item *managedItem) AddIngress(certificateARN string, ingress *kubernetes.Ingress, maxCerts int) bool {
+func (item *managedItem) AddIngress(certificateARNs []string, ingress *kubernetes.Ingress, maxCerts int) bool {
 	if item.scheme != ingress.Scheme() {
 		return false
 	}
@@ -86,13 +86,15 @@ func (item *managedItem) AddIngress(certificateARN string, ingress *kubernetes.I
 		return false
 	}
 
-	if ingresses, ok := item.ingresses[certificateARN]; ok {
-		item.ingresses[certificateARN] = append(ingresses, ingress)
-	} else {
-		if len(item.ingresses) >= maxCerts {
-			return false
+	for _, certificateARN := range certificateARNs {
+		if ingresses, ok := item.ingresses[certificateARN]; ok {
+			item.ingresses[certificateARN] = append(ingresses, ingress)
+		} else {
+			if len(item.ingresses) >= maxCerts {
+				return false
+			}
+			item.ingresses[certificateARN] = []*kubernetes.Ingress{ingress}
 		}
-		item.ingresses[certificateARN] = []*kubernetes.Ingress{ingress}
 	}
 
 	item.shared = ingress.Shared()
@@ -232,21 +234,25 @@ func buildManagedModel(certsProvider certs.CertificatesProvider, certsPerALB int
 	}
 
 	var (
-		certificateARN string
-		err            error
+		certificateARNs []string
+		err             error
 	)
 	for _, ingress := range ingresses {
-		certificateARN = ingress.CertificateARN()
-		if certificateARN == "" { // do discovery
-			certificateARN, err = discoverCertificateAndUpdateIngress(certsProvider, ingress)
+		certificateARN := ingress.CertificateARN()
+		if certificateARN != "" {
+			certificateARNs = append(certificateARNs, certificateARN)
+		}
+
+		if len(certificateARN) == 0 { // do discovery
+			certificateARNs, err = discoverCertificates(certsProvider, ingress)
 			if err != nil {
-				log.Printf("failed to find a certificate for %v: %v", ingress.CertHostname(), err)
+				log.Printf("failed to find certificates for %v: %v", ingress.CertHostnames(), err)
 				continue
 			}
 		} else { // validate that certificateARN exists
 			err := checkCertificate(certsProvider, certificateARN)
 			if err != nil {
-				log.Printf("Failed to find certificate with ARN %s: %v", certificateARN, err)
+				log.Printf("Failed to find certificates with ARN %s: %v", certificateARNs, err)
 				continue
 			}
 		}
@@ -255,7 +261,7 @@ func buildManagedModel(certsProvider certs.CertificatesProvider, certsPerALB int
 		// limit is exeeded.
 		added := false
 		for _, item := range model {
-			if item.AddIngress(certificateARN, ingress, certsPerALB) {
+			if item.AddIngress(certificateARNs, ingress, certsPerALB) {
 				added = true
 				break
 			}
@@ -265,8 +271,9 @@ func buildManagedModel(certsProvider certs.CertificatesProvider, certsPerALB int
 		// non-matching scheme or too many certificates, add a new
 		// stack.
 		if !added {
-			i := map[string][]*kubernetes.Ingress{
-				certificateARN: []*kubernetes.Ingress{ingress},
+			i := make(map[string][]*kubernetes.Ingress, len(certificateARNs))
+			for _, certificateARN := range certificateARNs {
+				i[certificateARN] = []*kubernetes.Ingress{ingress}
 			}
 			model = append(model, &managedItem{ingresses: i, scheme: ingress.Scheme(), shared: ingress.Shared()})
 		}
@@ -275,19 +282,24 @@ func buildManagedModel(certsProvider certs.CertificatesProvider, certsPerALB int
 	return model
 }
 
-func discoverCertificateAndUpdateIngress(certsProvider certs.CertificatesProvider, ingress *kubernetes.Ingress) (string, error) {
+func discoverCertificates(certsProvider certs.CertificatesProvider, ingress *kubernetes.Ingress) ([]string, error) {
 	knownCertificates, err := certsProvider.GetCertificates()
 	if err != nil {
-		return "", fmt.Errorf("discoverCertificateAndUpdateIngress failed to obtain certificates: %v", err)
+		return nil, fmt.Errorf("discoverCertificateAndUpdateIngress failed to obtain certificates: %v", err)
 	}
 
-	certificateSummary, err := certs.FindBestMatchingCertificate(knownCertificates, ingress.CertHostname())
+	certificateSummaries, err := certs.FindBestMatchingCertificates(knownCertificates, ingress.CertHostnames())
 	if err != nil {
-		return "", fmt.Errorf("discoverCertificateAndUpdateIngress failed to find a certificate for %q: %v",
-			ingress.CertHostname(), err)
+		return nil, fmt.Errorf("discoverCertificateAndUpdateIngress failed to find a certificate for %q: %v",
+			ingress.CertHostnames(), err)
 	}
-	ingress.SetCertificateARN(certificateSummary.ID())
-	return certificateSummary.ID(), nil
+
+	certs := make([]string, 0, len(certificateSummaries))
+	for _, cert := range certificateSummaries {
+		certs = append(certs, cert.ID())
+	}
+
+	return certs, nil
 }
 
 // checkCertificate checks that a certificate with the specified ARN exists in


### PR DESCRIPTION
This adds support for finding all matching certificates for an ingress in case multiple hostnames are defined.

Right now it will fail to create an ALB for the ingress if the certificate lookup fails for just one of the hostnames specified in the ingress. I'm not sure if it's better to fail or do best effort by creating an ALB with just the certificates it found.

Thoughts on that?

Fix #142