### PR TITLE
Streamline stack naming

### DIFF
--- a/aws/naming.go
+++ b/aws/naming.go
@@ -12,7 +12,7 @@ const (
 	maxStackNameLen = 128
 	uuidLen         = 36
 	nameSeparator   = "-"
-	stackNamePrefix = "ingress-alb"
+	stackNamePrefix = "kube-ingress-aws-controller"
 )
 
 var (

--- a/aws/naming.go
+++ b/aws/naming.go
@@ -9,12 +9,10 @@ import (
 )
 
 const (
-	shortHashLen = 7
-
-	maxLoadBalancerNameLen = 32
-	maxStackNameLen        = 128
-
-	nameSeparator = "-"
+	maxStackNameLen = 128
+	uuidLen         = 36
+	nameSeparator   = "-"
+	stackNamePrefix = "ingress-alb"
 )
 
 var (
@@ -22,17 +20,19 @@ var (
 	squeezeDashesRegex = regexp.MustCompile("[-]{2,}")
 )
 
-// normalizeStackName normalizes the stackName by normalizing the clusterID and
-// adding a uuid suffix.
+// normalizeStackName normalizes the stackName by normalizing the clusterID,
+// adding a stack name prefix and a uuid suffix.
 func normalizeStackName(clusterID string) string {
 	normalizedClusterID := squeezeDashesRegex.ReplaceAllString(
 		normalizationRegex.ReplaceAllString(clusterID, nameSeparator), nameSeparator)
 	lenClusterID := len(normalizedClusterID)
-	maxClusterIDLen := maxStackNameLen - shortHashLen - 1
+	// max cluser ID length is the max stack name length except stack name
+	// prefix, UUID and two separators.
+	maxClusterIDLen := maxStackNameLen - len(stackNamePrefix) - uuidLen - 2
 	if lenClusterID > maxClusterIDLen {
 		normalizedClusterID = normalizedClusterID[lenClusterID-maxClusterIDLen:]
 	}
 	normalizedClusterID = strings.Trim(normalizedClusterID, nameSeparator) // trim leading/trailing separators
 
-	return fmt.Sprintf("%s%s%s", normalizedClusterID, nameSeparator, uuid.New().String())
+	return fmt.Sprintf("%s%s%s%s%s", stackNamePrefix, nameSeparator, normalizedClusterID, nameSeparator, uuid.New().String())
 }

--- a/aws/naming_test.go
+++ b/aws/naming_test.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeStackName(t *testing.T) {
+	// test simple cluster ID
+	clusterID := "my-cluster"
+	normalized := normalizeStackName(clusterID)
+	expectedPrefix := stackNamePrefix + nameSeparator + clusterID + nameSeparator
+	if !strings.HasPrefix(normalized, expectedPrefix) {
+		t.Errorf("expected prefix %s, got %s", expectedPrefix, normalized)
+	}
+
+	// test that very long cluster ID gets cut off
+	longClusterID := strings.Repeat("a", maxStackNameLen)
+	normalized = normalizeStackName(longClusterID)
+	expectedClusterID := strings.Repeat("a", maxStackNameLen-len(stackNamePrefix)-uuidLen-2)
+	expectedPrefix = stackNamePrefix + nameSeparator + expectedClusterID + nameSeparator
+	if !strings.HasPrefix(normalized, expectedPrefix) {
+		t.Errorf("expected prefix %s, got %s", expectedPrefix, normalized)
+	}
+}


### PR DESCRIPTION
This cleans up the stack nameing code a bit and introduces a new naming
format that should work in all cases:

```
kube-ingress-aws-controller-<clusterID>-<UUID>
```

This naming convention will not affect existing ALB stacks, it's only
applied to new stacks.

Fixes #144 and #146 