### PR TITLE
Initial work for zalando-incubator/kube-ingress-aws-controller#38

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -182,7 +182,13 @@ func main() {
 	} else {
 		kubeConfig = kubernetes.InsecureConfig(apiServerBaseURL)
 	}
-	kubeAdapter, err = kubernetes.NewAdapter(kubeConfig, strings.Split(ingressClassFilters, ","))
+
+	if ingressClassFilters == "" {
+		kubeAdapter, err = kubernetes.NewAdapter(kubeConfig, []string{})
+	} else {
+		kubeAdapter, err = kubernetes.NewAdapter(kubeConfig, strings.Split(ingressClassFilters, ","))
+	}
+
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -202,6 +208,7 @@ func main() {
 	log.Printf("\tpublic subnet ids: %s", awsAdapter.FindLBSubnets(elbv2.LoadBalancerSchemeEnumInternetFacing))
 	log.Printf("\tEC2 filters: %s", awsAdapter.FiltersString())
 	log.Printf("\tCetificates Per ALB (SNI: %t): %d", certificatesPerALB > 1, certificatesPerALB)
+	log.Printf("\tIngress class filters: %s", kubeAdapter.IngressFiltersString())
 
 	go serveMetrics(metricsAddress)
 	quitCH := make(chan struct{})

--- a/controller.go
+++ b/controller.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 
 	"flag"
 	"time"
@@ -42,6 +43,7 @@ var (
 	certTTL                    time.Duration
 	stackTerminationProtection bool
 	idleConnectionTimeout      time.Duration
+	ingressClassFilters        string
 )
 
 func loadSettings() error {
@@ -73,6 +75,7 @@ func loadSettings() error {
 	flag.DurationVar(&idleConnectionTimeout, "idle-connection-timeout", aws.DefaultIdleConnectionTimeout,
 		"sets the idle connection timeout of all ALBs. The flag accepts a value acceptable to time.ParseDuration and are between 1s and 4000s.")
 	flag.StringVar(&metricsAddress, "metrics-address", ":7979", "defines where to serve metrics")
+	flag.StringVar(&ingressClassFilters, "ingress-class-filter", "", "optional comma-seperated list of kubernetes.io/ingress.class annotation values to filter behaviour on. ")
 
 	flag.Parse()
 
@@ -179,7 +182,7 @@ func main() {
 	} else {
 		kubeConfig = kubernetes.InsecureConfig(apiServerBaseURL)
 	}
-	kubeAdapter, err = kubernetes.NewAdapter(kubeConfig)
+	kubeAdapter, err = kubernetes.NewAdapter(kubeConfig, strings.Split(ingressClassFilters, ","))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -202,7 +202,6 @@ func (a *Adapter) ListIngress() ([]*Ingress, error) {
 			ret[i] = newIngressFromKube(ingress)
 		}
 	}
-	fmt.Println(ret)
 	return ret, nil
 }
 

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -180,8 +180,7 @@ func NewAdapter(config *Config, ingressClassFilters []string) (*Adapter, error) 
 
 // Get ingress class filters that are used to filter ingresses acted upon.
 func (a *Adapter) IngressFiltersString() string {
-        result := fmt.Sprintf("%s", strings.Join(a.ingressFilters, ","))
-        return strings.TrimSpace(result)
+        return strings.TrimSpace(strings.Join(a.ingressFilters, ","))
 }
 
 // ListIngress can be used to obtain the list of ingress resources for all namespaces.

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
 )
@@ -175,6 +176,12 @@ func NewAdapter(config *Config, ingressClassFilters []string) (*Adapter, error) 
 		return nil, err
 	}
 	return &Adapter{kubeClient: c, ingressFilters: ingressClassFilters}, nil
+}
+
+// Get ingress class filters that are used to filter ingresses acted upon.
+func (a *Adapter) IngressFiltersString() string {
+        result := fmt.Sprintf("%s", strings.Join(a.ingressFilters, ","))
+        return strings.TrimSpace(result)
 }
 
 // ListIngress can be used to obtain the list of ingress resources for all namespaces.

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -176,9 +176,10 @@ func (c *mockClient) patch(res string, payload []byte) (io.ReadCloser, error) {
 }
 
 var testConfig = InsecureConfig("dummy-url")
+var testIngressFilter = []string{"skipper"}
 
 func TestListIngress(t *testing.T) {
-	a, _ := NewAdapter(testConfig)
+	a, _ := NewAdapter(testConfig, testIngressFilter)
 	client := &mockClient{}
 	a.kubeClient = client
 	ingresses, err := a.ListIngress()
@@ -196,7 +197,7 @@ func TestListIngress(t *testing.T) {
 }
 
 func TestUpdateIngressLoadBalancer(t *testing.T) {
-	a, _ := NewAdapter(testConfig)
+	a, _ := NewAdapter(testConfig, testIngressFilter)
 	client := &mockClient{}
 	a.kubeClient = client
 	ing := &Ingress{
@@ -231,7 +232,7 @@ func TestBrokenConfig(t *testing.T) {
 		{"broken-cert", &Config{BaseURL: "dontcare", TLSClientConfig: TLSClientConfig{CAFile: "testdata/broken.pem"}}},
 	} {
 		t.Run(fmt.Sprintf("%v", test.cfg), func(t *testing.T) {
-			_, err := NewAdapter(test.cfg)
+			_, err := NewAdapter(test.cfg, testIngressFilter)
 			if err == nil {
 				t.Error("expected an error")
 			}

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -65,6 +65,7 @@ const (
 	ingressCertificateDomainAnnotation = "zalando.org/aws-load-balancer-ssl-cert-domain"
 	ingressSchemeAnnotation            = "zalando.org/aws-load-balancer-scheme"
 	ingressSharedAnnotation            = "zalando.org/aws-load-balancer-shared"
+	ingressClassAnnotation             = "kubernetes.io/ingress.class"
 )
 
 func (i *ingress) getAnnotationsString(key string, defaultValue string) string {

--- a/kubernetes/ingress_test.go
+++ b/kubernetes/ingress_test.go
@@ -21,7 +21,11 @@ func TestListIngresses(t *testing.T) {
 	}))
 	defer testServer.Close()
 	kubeClient, _ := newSimpleClient(&Config{BaseURL: testServer.URL})
-	want := newList(newIngress("fixture01", nil, "example.org", "fixture01"))
+	want := newList(
+		newIngress("fixture01", nil, "example.org", "fixture01"),
+		newIngress("fixture02", map[string]interface{}{ingressClassAnnotation: "skipper"}, "skipper.example.org", "fixture02"),
+		newIngress("fixture03", map[string]interface{}{ingressClassAnnotation: "other"}, "other.example.org", "fixture03"),
+	)
 	got, err := listIngress(kubeClient)
 	if err != nil {
 		t.Errorf("unexpected error from listIngresses: %v", err)
@@ -169,7 +173,11 @@ func newIngress(name string, annotations map[string]interface{}, hostname string
 		},
 	}
 	if arn != "" {
-		ret.Metadata.Annotations = map[string]interface{}{ingressCertificateARNAnnotation: arn}
+		if annotations == nil {
+			ret.Metadata.Annotations = map[string]interface{}{ingressCertificateARNAnnotation: arn}
+		} else {
+			ret.Metadata.Annotations[ingressCertificateARNAnnotation] = arn
+		}
 	}
 	if hostname != "" {
 		ret.Status.LoadBalancer = ingressLoadBalancerStatus{

--- a/kubernetes/testdata/fixture01.json
+++ b/kubernetes/testdata/fixture01.json
@@ -26,6 +26,50 @@
           ]
         }
       }
+    },
+    {
+      "metadata": {
+        "name": "fixture02",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/fixture02",
+        "uid": "fixture02",
+        "resourceVersion": "42",
+        "generation": 1,
+        "creationTimestamp": "2016-11-29T14:53:42Z",
+        "annotations": {
+          "zalando.org/aws-load-balancer-ssl-cert": "fixture02",
+          "kubernetes.io/ingress.class": "skipper"
+        }
+      },
+      "status": {
+        "loadBalancer": {
+          "ingress": [
+            {"hostname": "skipper.example.org"}
+          ]
+        }
+      }
+    },
+    {
+      "metadata": {
+        "name": "fixture03",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/fixture03",
+        "uid": "fixture03",
+        "resourceVersion": "42",
+        "generation": 1,
+        "creationTimestamp": "2016-11-29T14:53:42Z",
+        "annotations": {
+          "zalando.org/aws-load-balancer-ssl-cert": "fixture03",
+          "kubernetes.io/ingress.class": "other"
+        }
+      },
+      "status": {
+        "loadBalancer": {
+          "ingress": [
+            {"hostname": "other.example.org"}
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Implements a new flag -ingress-class-filter which if specified is
interpreted as a comma seperated list of values which will be used
as a filter to match kubernetes.io/ingress.class annotations. If
the annotation is not set, or does match, the ingress will be hidden
from the ingress controller and not acted upon.

As of this commit the work passes a 'make test' but requires
further testing.