### PR TITLE
Add support for multiple controller instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,21 @@ built from this codebase. You can deploy it with 2 easy steps:
 If you use [Kops](https://github.com/kubernetes/kops) to create your
 cluster, please use our [deployment guide for Kops](deploy/kops.md)
 
+## Running multiple instances
+
+In some cases it might be useful to run multiple instances of this controller:
+
+* Isolating internal vs external traffic
+* Using a different set of traffic processing nodes
+* Using different frontend routers (e.g.: Skipper and Traefik)
+
+You can use the flag `-operator-id` to set a token that will be used to isolate resources between controller instances.
+This value will be used to tag those resources.
+
+If you don't pass an ID, the default `kube-ingress-aws-controller` will be used.
+
+Usually you would want to combine this flag with `ingress-class-filter` so different types of ingresses are associated with the different controllers.
+
 ## Trying it out
 
 The Ingress Controller's responsibility is limited to managing load balancers, as described above. To have a fully

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -16,7 +16,6 @@ const (
 	clusterIDTagPrefix         = "kubernetes.io/cluster/"
 	resourceLifecycleOwned     = "owned"
 	kubernetesCreatorTag       = "kubernetes:application"
-	kubernetesCreatorValue     = "kube-ingress-aws-controller"
 	autoScalingGroupNameTag    = "aws:autoscaling:groupName"
 	runningState               = 16 // See https://github.com/aws/aws-sdk-go/blob/master/service/ec2/api.go, type InstanceState
 	stoppedState               = 80 // See https://github.com/aws/aws-sdk-go/blob/master/service/ec2/api.go, type InstanceState
@@ -288,7 +287,7 @@ func findSecurityGroupWithClusterID(svc ec2iface.EC2API, clusterID string) (*sec
 			{
 				Name: aws.String("tag-value"),
 				Values: []*string{
-					aws.String(kubernetesCreatorValue),
+					aws.String(DefaultControllerID),
 				},
 			},
 		},

--- a/controller.go
+++ b/controller.go
@@ -44,6 +44,7 @@ var (
 	stackTerminationProtection bool
 	idleConnectionTimeout      time.Duration
 	ingressClassFilters        string
+	controllerID               string
 )
 
 func loadSettings() error {
@@ -76,6 +77,7 @@ func loadSettings() error {
 		"sets the idle connection timeout of all ALBs. The flag accepts a value acceptable to time.ParseDuration and are between 1s and 4000s.")
 	flag.StringVar(&metricsAddress, "metrics-address", ":7979", "defines where to serve metrics")
 	flag.StringVar(&ingressClassFilters, "ingress-class-filter", "", "optional comma-seperated list of kubernetes.io/ingress.class annotation values to filter behaviour on. ")
+	flag.StringVar(&controllerID, "controller-id", aws.DefaultControllerID, "controller ID used to differentiate resources from multiple aws ingress controller instances")
 
 	flag.Parse()
 
@@ -163,7 +165,8 @@ func main() {
 		WithCreationTimeout(creationTimeout).
 		WithCustomTemplate(cfCustomTemplate).
 		WithStackTerminationProtection(stackTerminationProtection).
-		WithIdleConnectionTimeout(idleConnectionTimeout)
+		WithIdleConnectionTimeout(idleConnectionTimeout).
+		WithControllerID(controllerID)
 
 	certificatesProvider, err := certs.NewCachingProvider(
 		certPollingInterval,


### PR DESCRIPTION
This allows multiple instances of kube-aws-ingress-controller to coexist in the same cluster.

It allows to properly split different types of trafic or routers (using Skipper and another router) at the same time.