### PR TITLE
Add support for using different health check and upstream ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,17 +284,19 @@ If you don't pass an ID, the default `kube-ingress-aws-controller` will be used.
 
 Usually you would want to combine this flag with `ingress-class-filter` so different types of ingresses are associated with the different controllers.
 
-## Upstream and Health Check Ports
+## Target and Health Check Ports
 
-By default the port 9999 is used as both health check and upstream. This means that Skipper or any other traffic router
-you're using needs to be listening on that port.
+By default the port 9999 is used as both health check and target port. This
+means that Skipper or any other traffic router you're using needs to be
+listening on that port.
 
-If you want to change the default ports, you can control it using the `-upstream-port` and `-health-check-port` flags.
+If you want to change the default ports, you can control it using the
+`-target-port` and `-health-check-port` flags.
 
 ### Backward Compatibility
 
-The controller used to have only the `-health-check-port` flag available, and would use the same port as health check and the upstream.
-Those ports are now configured individually. If you relied on this behavior, please include the `-upstream-port` in your configuration.
+The controller used to have only the `-health-check-port` flag available, and would use the same port as health check and the target port.
+Those ports are now configured individually. If you relied on this behavior, please include the `-target-port` in your configuration.
 
 ## Trying it out
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,18 @@ If you don't pass an ID, the default `kube-ingress-aws-controller` will be used.
 
 Usually you would want to combine this flag with `ingress-class-filter` so different types of ingresses are associated with the different controllers.
 
+## Upstream and Health Check Ports
+
+By default the port 9999 is used as both health check and upstream. This means that Skipper or any other traffic router
+you're using needs to be listening on that port.
+
+If you want to change the default ports, you can control it using the `-upstream-port` and `-health-check-port` flags.
+
+### Backward Compatibility
+
+The controller used to have only the `-health-check-port` flag available, and would use the same port as health check and the upstream.
+Those ports are now configured individually. If you relied on this behavior, please include the `-upstream-port` in your configuration.
+
 ## Trying it out
 
 The Ingress Controller's responsibility is limited to managing load balancers, as described above. To have a fully

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -44,7 +44,7 @@ type Adapter struct {
 	healthCheckPath            string
 	healthCheckPort            uint
 	healthCheckInterval        time.Duration
-	upstreamPort               uint
+	targetPort                 uint
 	creationTimeout            time.Duration
 	idleConnectionTimeout      time.Duration
 	stackTTL                   time.Duration
@@ -68,7 +68,7 @@ type configProviderFunc func() client.ConfigProvider
 const (
 	DefaultHealthCheckPath           = "/kube-system/healthz"
 	DefaultHealthCheckPort           = 9999
-	DefaultUpstreamPort              = 9999
+	DefaultTargetPort                = 9999
 	DefaultHealthCheckInterval       = 10 * time.Second
 	DefaultCertificateUpdateInterval = 30 * time.Minute
 	DefaultCreationTimeout           = 5 * time.Minute
@@ -131,7 +131,7 @@ func NewAdapter() (adapter *Adapter, err error) {
 		cloudformation:      cloudformation.New(p),
 		healthCheckPath:     DefaultHealthCheckPath,
 		healthCheckPort:     DefaultHealthCheckPort,
-		upstreamPort:        DefaultUpstreamPort,
+		targetPort:          DefaultTargetPort,
 		healthCheckInterval: DefaultHealthCheckInterval,
 		creationTimeout:     DefaultCreationTimeout,
 		stackTTL:            DefaultStackTTL,
@@ -172,10 +172,10 @@ func (a *Adapter) WithHealthCheckPort(port uint) *Adapter {
 	return a
 }
 
-// WithUpstreamPort returns the receiver adapter after changing the upstream port that will be used by
+// WithTargetPort returns the receiver adapter after changing the target port that will be used by
 // the resources created by the adapter
-func (a *Adapter) WithUpstreamPort(port uint) *Adapter {
-	a.upstreamPort = port
+func (a *Adapter) WithTargetPort(port uint) *Adapter {
+	a.targetPort = port
 	return a
 }
 
@@ -379,7 +379,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, owner string) (s
 			port:     a.healthCheckPort,
 			interval: a.healthCheckInterval,
 		},
-		upstreamPort:                 a.upstreamPort,
+		targetPort:                   a.targetPort,
 		timeoutInMinutes:             uint(a.creationTimeout.Minutes()),
 		stackTerminationProtection:   a.stackTerminationProtection,
 		idleConnectionTimeoutSeconds: uint(a.idleConnectionTimeout.Seconds()),
@@ -403,7 +403,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 			port:     a.healthCheckPort,
 			interval: a.healthCheckInterval,
 		},
-		upstreamPort:                 a.upstreamPort,
+		targetPort:                   a.targetPort,
 		timeoutInMinutes:             uint(a.creationTimeout.Minutes()),
 		stackTerminationProtection:   a.stackTerminationProtection,
 		idleConnectionTimeoutSeconds: uint(a.idleConnectionTimeout.Seconds()),

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -44,6 +44,7 @@ type Adapter struct {
 	healthCheckPath            string
 	healthCheckPort            uint
 	healthCheckInterval        time.Duration
+	upstreamPort               uint
 	creationTimeout            time.Duration
 	idleConnectionTimeout      time.Duration
 	stackTTL                   time.Duration
@@ -67,6 +68,7 @@ type configProviderFunc func() client.ConfigProvider
 const (
 	DefaultHealthCheckPath           = "/kube-system/healthz"
 	DefaultHealthCheckPort           = 9999
+	DefaultUpstreamPort              = 9999
 	DefaultHealthCheckInterval       = 10 * time.Second
 	DefaultCertificateUpdateInterval = 30 * time.Minute
 	DefaultCreationTimeout           = 5 * time.Minute
@@ -128,6 +130,7 @@ func NewAdapter() (adapter *Adapter, err error) {
 		cloudformation:      cloudformation.New(p),
 		healthCheckPath:     DefaultHealthCheckPath,
 		healthCheckPort:     DefaultHealthCheckPort,
+		upstreamPort:        DefaultUpstreamPort,
 		healthCheckInterval: DefaultHealthCheckInterval,
 		creationTimeout:     DefaultCreationTimeout,
 		stackTTL:            DefaultStackTTL,
@@ -165,6 +168,13 @@ func (a *Adapter) WithHealthCheckPath(path string) *Adapter {
 // the resources created by the adapter
 func (a *Adapter) WithHealthCheckPort(port uint) *Adapter {
 	a.healthCheckPort = port
+	return a
+}
+
+// WithUpstreamPort returns the receiver adapter after changing the upstream port that will be used by
+// the resources created by the adapter
+func (a *Adapter) WithUpstreamPort(port uint) *Adapter {
+	a.upstreamPort = port
 	return a
 }
 
@@ -363,6 +373,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, owner string) (s
 			port:     a.healthCheckPort,
 			interval: a.healthCheckInterval,
 		},
+		upstreamPort:                 a.upstreamPort,
 		timeoutInMinutes:             uint(a.creationTimeout.Minutes()),
 		stackTerminationProtection:   a.stackTerminationProtection,
 		idleConnectionTimeoutSeconds: uint(a.idleConnectionTimeout.Seconds()),
@@ -386,6 +397,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 			port:     a.healthCheckPort,
 			interval: a.healthCheckInterval,
 		},
+		upstreamPort:                 a.upstreamPort,
 		timeoutInMinutes:             uint(a.creationTimeout.Minutes()),
 		stackTerminationProtection:   a.stackTerminationProtection,
 		idleConnectionTimeoutSeconds: uint(a.idleConnectionTimeout.Seconds()),

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -128,6 +128,7 @@ const (
 	parameterTargetGroupHealthCheckPathParameter     = "TargetGroupHealthCheckPathParameter"
 	parameterTargetGroupHealthCheckPortParameter     = "TargetGroupHealthCheckPortParameter"
 	parameterTargetGroupHealthCheckIntervalParameter = "TargetGroupHealthCheckIntervalParameter"
+	parameterTargetUpstreamPortParameter             = "TargetGroupUpstreamPortParameter"
 	parameterTargetGroupVPCIDParameter               = "TargetGroupVPCIDParameter"
 	parameterListenerCertificatesParameter           = "ListenerCertificatesParameter"
 )
@@ -142,6 +143,7 @@ type stackSpec struct {
 	clusterID                    string
 	vpcID                        string
 	healthCheck                  *healthCheck
+	upstreamPort                 uint
 	timeoutInMinutes             uint
 	customTemplate               string
 	stackTerminationProtection   bool
@@ -169,6 +171,7 @@ func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfParam(parameterLoadBalancerSecurityGroupParameter, spec.securityGroupID),
 			cfParam(parameterLoadBalancerSubnetsParameter, strings.Join(spec.subnets, ",")),
 			cfParam(parameterTargetGroupVPCIDParameter, spec.vpcID),
+			cfParam(parameterTargetUpstreamPortParameter, fmt.Sprintf("%d", spec.upstreamPort)),
 		},
 		Tags: []*cloudformation.Tag{
 			cfTag(kubernetesCreatorTag, spec.controllerID),

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -128,7 +128,7 @@ const (
 	parameterTargetGroupHealthCheckPathParameter     = "TargetGroupHealthCheckPathParameter"
 	parameterTargetGroupHealthCheckPortParameter     = "TargetGroupHealthCheckPortParameter"
 	parameterTargetGroupHealthCheckIntervalParameter = "TargetGroupHealthCheckIntervalParameter"
-	parameterTargetUpstreamPortParameter             = "TargetGroupUpstreamPortParameter"
+	parameterTargetTargetPortParameter               = "TargetGroupTargetPortParameter"
 	parameterTargetGroupVPCIDParameter               = "TargetGroupVPCIDParameter"
 	parameterListenerCertificatesParameter           = "ListenerCertificatesParameter"
 )
@@ -143,7 +143,7 @@ type stackSpec struct {
 	clusterID                    string
 	vpcID                        string
 	healthCheck                  *healthCheck
-	upstreamPort                 uint
+	targetPort                   uint
 	timeoutInMinutes             uint
 	customTemplate               string
 	stackTerminationProtection   bool
@@ -171,7 +171,7 @@ func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfParam(parameterLoadBalancerSecurityGroupParameter, spec.securityGroupID),
 			cfParam(parameterLoadBalancerSubnetsParameter, strings.Join(spec.subnets, ",")),
 			cfParam(parameterTargetGroupVPCIDParameter, spec.vpcID),
-			cfParam(parameterTargetUpstreamPortParameter, fmt.Sprintf("%d", spec.upstreamPort)),
+			cfParam(parameterTargetTargetPortParameter, fmt.Sprintf("%d", spec.targetPort)),
 		},
 		Tags: []*cloudformation.Tag{
 			cfTag(kubernetesCreatorTag, spec.controllerID),

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	"crypto/sha256"
 	"github.com/mweagle/go-cloudformation"
 	"sort"
-	"crypto/sha256"
 )
 
 func hashARNs(certARNs []string) []byte {
@@ -48,9 +48,9 @@ func generateTemplate(certs map[string]time.Time, idleConnectionTimeoutSeconds u
 			Description: "The healthcheck port",
 			Default:     "9999",
 		},
-		"TargetGroupUpstreamPortParameter": &cloudformation.Parameter{
+		"TargetGroupTargetPortParameter": &cloudformation.Parameter{
 			Type:        "Number",
-			Description: "The upstream router port",
+			Description: "The target port",
 			Default:     "9999",
 		},
 		"TargetGroupHealthCheckIntervalParameter": &cloudformation.Parameter{
@@ -142,7 +142,7 @@ func generateTemplate(certs map[string]time.Time, idleConnectionTimeoutSeconds u
 		HealthCheckIntervalSeconds: cloudformation.Ref("TargetGroupHealthCheckIntervalParameter").Integer(),
 		HealthCheckPath:            cloudformation.Ref("TargetGroupHealthCheckPathParameter").String(),
 		HealthCheckPort:            cloudformation.Ref("TargetGroupHealthCheckPortParameter").String(),
-		Port:                       cloudformation.Ref("TargetGroupUpstreamPortParameter").Integer(),
+		Port:                       cloudformation.Ref("TargetGroupTargetPortParameter").Integer(),
 		Protocol:                   cloudformation.String("HTTP"),
 		VPCID:                      cloudformation.Ref("TargetGroupVPCIDParameter").String(),
 	})

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -48,6 +48,11 @@ func generateTemplate(certs map[string]time.Time, idleConnectionTimeoutSeconds u
 			Description: "The healthcheck port",
 			Default:     "9999",
 		},
+		"TargetGroupUpstreamPortParameter": &cloudformation.Parameter{
+			Type:        "Number",
+			Description: "The upstream router port",
+			Default:     "9999",
+		},
 		"TargetGroupHealthCheckIntervalParameter": &cloudformation.Parameter{
 			Type:        "Number",
 			Description: "The healthcheck interval",
@@ -136,7 +141,8 @@ func generateTemplate(certs map[string]time.Time, idleConnectionTimeoutSeconds u
 	template.AddResource("TG", &cloudformation.ElasticLoadBalancingV2TargetGroup{
 		HealthCheckIntervalSeconds: cloudformation.Ref("TargetGroupHealthCheckIntervalParameter").Integer(),
 		HealthCheckPath:            cloudformation.Ref("TargetGroupHealthCheckPathParameter").String(),
-		Port:                       cloudformation.Ref("TargetGroupHealthCheckPortParameter").Integer(),
+		HealthCheckPort:            cloudformation.Ref("TargetGroupHealthCheckPortParameter").String(),
+		Port:                       cloudformation.Ref("TargetGroupUpstreamPortParameter").Integer(),
 		Protocol:                   cloudformation.String("HTTP"),
 		VPCID:                      cloudformation.Ref("TargetGroupVPCIDParameter").String(),
 	})

--- a/controller.go
+++ b/controller.go
@@ -38,7 +38,7 @@ var (
 	healthCheckPath            string
 	healthCheckPort            uint
 	healthCheckInterval        time.Duration
-	upstreamPort               uint
+	targetPort                 uint
 	metricsAddress             string
 	disableSNISupport          bool
 	certTTL                    time.Duration
@@ -72,8 +72,8 @@ func loadSettings() error {
 		"sets the health check path for the created target groups")
 	flag.UintVar(&healthCheckPort, "health-check-port", aws.DefaultHealthCheckPort,
 		"sets the health check port for the created target groups")
-	flag.UintVar(&upstreamPort, "upstream-port", 9999,
-		"sets the upstream port for the created target groups")
+	flag.UintVar(&targetPort, "target-port", 9999,
+		"sets the target port for the created target groups")
 	flag.DurationVar(&healthCheckInterval, "health-check-interval", aws.DefaultHealthCheckInterval,
 		"sets the health check interval for the created target groups. The flag accepts a value "+
 			"acceptable to time.ParseDuration")
@@ -110,8 +110,8 @@ func loadSettings() error {
 		return fmt.Errorf("invalid health check port: %d. please use a valid TCP port", healthCheckPort)
 	}
 
-	if upstreamPort == 0 || upstreamPort > 65535 {
-		return fmt.Errorf("invalid upstream port: %d. please use a valid TCP port", upstreamPort)
+	if targetPort == 0 || targetPort > 65535 {
+		return fmt.Errorf("invalid target port: %d. please use a valid TCP port", targetPort)
 	}
 
 	if cfCustomTemplate != "" {
@@ -177,7 +177,7 @@ func main() {
 		WithHealthCheckPath(healthCheckPath).
 		WithHealthCheckPort(healthCheckPort).
 		WithHealthCheckInterval(healthCheckInterval).
-		WithUpstreamPort(upstreamPort).
+		WithTargetPort(targetPort).
 		WithCreationTimeout(creationTimeout).
 		WithCustomTemplate(cfCustomTemplate).
 		WithStackTerminationProtection(stackTerminationProtection).


### PR DESCRIPTION
This allows the usage of routers that have different ports for upstream and health check ports.

It also makes clear the distinction between the health check port and the upstream one, as this PR started
when we were trying to have different routers in the same machine and we thought that the port 9999 was hardcoded.

The legacy behaviour of using the health check port as the upstream port is maintained for backward compatibility.