### PR TITLE
Remove _ from CF resource name

### DIFF
--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -71,8 +71,7 @@ func generateTemplate(certs map[string]time.Time, idleConnectionTimeoutSeconds u
 	})
 
 	if len(certs) > 0 {
-		// Sort the certificate names so we have a stable order. As a nice side effect, a wildcard cert will always
-		// be selected as the default one if it's present.
+		// Sort the certificate names so we have a stable order.
 		certificateARNs := make([]string, 0, len(certs))
 		for certARN := range certs {
 			certificateARNs = append(certificateARNs, certARN)

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -109,7 +109,7 @@ func generateTemplate(certs map[string]time.Time, idleConnectionTimeoutSeconds u
 		}
 
 		// Use a new resource name every time to avoid a bug where CloudFormation fails to perform an update properly
-		resourceName := fmt.Sprintf("HTTPSListenerCertificate_%x", hashARNs(certificateARNs))
+		resourceName := fmt.Sprintf("HTTPSListenerCertificate%x", hashARNs(certificateARNs))
 		template.AddResource(resourceName, &cloudformation.ElasticLoadBalancingV2ListenerCertificate{
 			Certificates: &certificateList,
 			ListenerArn:  cloudformation.Ref("HTTPSListener").String(),


### PR DESCRIPTION
Follow up of #162, apparently _ is unsupported in CF resource names. Fix an incorrect comment as well.