### PR TITLE
filter subnets on cluster ID tag before consideration

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -434,7 +434,7 @@ func buildManifest(awsAdapter *Adapter) (*manifest, error) {
 		return nil, err
 	}
 
-	subnets, err := getSubnets(awsAdapter.ec2, instanceDetails.vpcID)
+	subnets, err := getSubnets(awsAdapter.ec2, instanceDetails.vpcID, clusterID)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -151,7 +151,7 @@ func findFirstRunningInstance(resp *ec2.DescribeInstancesOutput) (*ec2.Instance,
 	return nil, ErrNoRunningInstances
 }
 
-func getSubnets(svc ec2iface.EC2API, vpcID, clusterId string) ([]*subnetDetails, error) {
+func getSubnets(svc ec2iface.EC2API, vpcID, clusterID string) ([]*subnetDetails, error) {
 	params := &ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -181,7 +181,7 @@ func getSubnets(svc ec2iface.EC2API, vpcID, clusterId string) ([]*subnetDetails,
 			return nil, err
 		}
 		tags := convertEc2Tags(sn.Tags)
-		if _, ok := tags[clusterIDTagPrefix + clusterId]; ok {
+		if _, ok := tags[clusterIDTagPrefix + clusterID]; ok {
 			ret = append(ret, &subnetDetails{
 				id:               subnetID,
 				availabilityZone: az,

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -181,8 +181,7 @@ func getSubnets(svc ec2iface.EC2API, vpcID, clusterId string) ([]*subnetDetails,
 			return nil, err
 		}
 		tags := convertEc2Tags(sn.Tags)
-		_, subnetHasClusterTag := tags[clusterIDTagPrefix + clusterId]
-		if subnetHasClusterTag {
+		if _, ok := tags[clusterIDTagPrefix + clusterId]; ok {
 			ret = append(ret, &subnetDetails{
 				id:               subnetID,
 				availabilityZone: az,

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -151,7 +151,7 @@ func findFirstRunningInstance(resp *ec2.DescribeInstancesOutput) (*ec2.Instance,
 	return nil, ErrNoRunningInstances
 }
 
-func getSubnets(svc ec2iface.EC2API, vpcID string) ([]*subnetDetails, error) {
+func getSubnets(svc ec2iface.EC2API, vpcID string, clusterId string) ([]*subnetDetails, error) {
 	params := &ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -160,6 +160,10 @@ func getSubnets(svc ec2iface.EC2API, vpcID string) ([]*subnetDetails, error) {
 					aws.String(vpcID),
 				},
 			},
+                        {
+                                Name:   aws.String("tag:" + clusterIDTagPrefix + clusterId),
+                                Values: []*string{aws.String(resourceLifecycleOwned)},
+                        },
 		},
 	}
 	resp, err := svc.DescribeSubnets(params)

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -172,8 +173,9 @@ func getSubnets(svc ec2iface.EC2API, vpcID, clusterID string) ([]*subnetDetails,
 		return nil, err
 	}
 
-	ret := make([]*subnetDetails, 0)
-	for _, sn := range resp.Subnets {
+	retAll      := make([]*subnetDetails, len(resp.Subnets))
+	retFiltered := make([]*subnetDetails, 0)
+	for i, sn := range resp.Subnets {
 		az := aws.StringValue(sn.AvailabilityZone)
 		subnetID := aws.StringValue(sn.SubnetId)
 		isPublic, err := isSubnetPublic(rt, subnetID)
@@ -181,8 +183,14 @@ func getSubnets(svc ec2iface.EC2API, vpcID, clusterID string) ([]*subnetDetails,
 			return nil, err
 		}
 		tags := convertEc2Tags(sn.Tags)
+		retAll[i] = &subnetDetails{
+			id:               subnetID,
+			availabilityZone: az,
+			public:           isPublic,
+			tags:             tags,
+		}
 		if _, ok := tags[clusterIDTagPrefix + clusterID]; ok {
-			ret = append(ret, &subnetDetails{
+			retFiltered = append(retFiltered, &subnetDetails{
 				id:               subnetID,
 				availabilityZone: az,
 				public:           isPublic,
@@ -190,8 +198,13 @@ func getSubnets(svc ec2iface.EC2API, vpcID, clusterID string) ([]*subnetDetails,
 			})
 		}
 	}
-	return ret, nil
-
+	// Fall back to full list of subnets if none matching expected tagging are found, with a stern warning
+	// https://github.com/kubernetes/kubernetes/blob/v1.10.3/pkg/cloudprovider/providers/aws/aws.go#L3009
+	if len(retFiltered) == 0 {
+		log.Printf("No tagged subnets found; considering all subnets. This is likely to be an error in a future versions.")
+		return retAll, nil
+	}
+	return retFiltered, nil
 }
 
 func convertEc2Tags(instanceTags []*ec2.Tag) map[string]string {

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -201,7 +201,7 @@ func getSubnets(svc ec2iface.EC2API, vpcID, clusterID string) ([]*subnetDetails,
 	// Fall back to full list of subnets if none matching expected tagging are found, with a stern warning
 	// https://github.com/kubernetes/kubernetes/blob/v1.10.3/pkg/cloudprovider/providers/aws/aws.go#L3009
 	if len(retFiltered) == 0 {
-		log.Printf("No tagged subnets found; considering all subnets. This is likely to be an error in a future versions.")
+		log.Printf("No tagged subnets found; considering all subnets. This is likely to be an error in future versions.")
 		return retAll, nil
 	}
 	return retFiltered, nil

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -151,7 +151,7 @@ func findFirstRunningInstance(resp *ec2.DescribeInstancesOutput) (*ec2.Instance,
 	return nil, ErrNoRunningInstances
 }
 
-func getSubnets(svc ec2iface.EC2API, vpcID string, clusterId string) ([]*subnetDetails, error) {
+func getSubnets(svc ec2iface.EC2API, vpcID, clusterId string) ([]*subnetDetails, error) {
 	params := &ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -175,8 +175,8 @@ func TestGetSubnets(t *testing.T) {
 			"success-call",
 			ec2MockOutputs{
 				describeSubnets: R(mockDSOutput(
-					testSubnet{id: "foo1", name: "bar1", az: "baz1", tags: map[string]string{elbRoleTagName: ""}},
-					testSubnet{id: "foo2", name: "bar2", az: "baz2"},
+					testSubnet{id: "foo1", name: "bar1", az: "baz1", tags: map[string]string{elbRoleTagName: "", clusterIDTagPrefix + "bar": "shared"}},
+					testSubnet{id: "foo2", name: "bar2", az: "baz2", tags: map[string]string{clusterIDTagPrefix + "bar": "shared"}},
 				), nil),
 				describeRouteTables: R(mockDRTOutput(
 					testRouteTable{subnetID: "foo1", gatewayIds: []string{"igw-foo1"}},
@@ -184,8 +184,8 @@ func TestGetSubnets(t *testing.T) {
 				), nil),
 			},
 			[]*subnetDetails{
-				{id: "foo1", availabilityZone: "baz1", public: true, tags: map[string]string{nameTag: "bar1", elbRoleTagName: ""}},
-				{id: "foo2", availabilityZone: "baz2", public: true, tags: map[string]string{nameTag: "bar2"}},
+				{id: "foo1", availabilityZone: "baz1", public: true, tags: map[string]string{nameTag: "bar1", elbRoleTagName: "", clusterIDTagPrefix + "bar": "shared"}},
+				{id: "foo2", availabilityZone: "baz2", public: true, tags: map[string]string{nameTag: "bar2", clusterIDTagPrefix + "bar": "shared"}},
 			},
 			false,
 		},

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -218,7 +218,7 @@ func TestGetSubnets(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%v", test.name), func(t *testing.T) {
 			ec2 := &mockEc2Client{outputs: test.responses}
-			got, err := getSubnets(ec2, "foo")
+			got, err := getSubnets(ec2, "foo", "bar")
 			assertResultAndError(t, test.want, got, test.wantError, err)
 		})
 	}

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -172,7 +172,25 @@ func TestGetSubnets(t *testing.T) {
 		wantError bool
 	}{
 		{
-			"success-call",
+			"success-call-nofilter",
+			ec2MockOutputs{
+				describeSubnets: R(mockDSOutput(
+					testSubnet{id: "foo1", name: "bar1", az: "baz1", tags: map[string]string{elbRoleTagName: ""}},
+					testSubnet{id: "foo2", name: "bar2", az: "baz2"},
+				), nil),
+				describeRouteTables: R(mockDRTOutput(
+					testRouteTable{subnetID: "foo1", gatewayIds: []string{"igw-foo1"}},
+					testRouteTable{subnetID: "mismatch", gatewayIds: []string{"igw-foo2"}, main: true},
+				), nil),
+			},
+			[]*subnetDetails{
+				{id: "foo1", availabilityZone: "baz1", public: true, tags: map[string]string{nameTag: "bar1", elbRoleTagName: ""}},
+				{id: "foo2", availabilityZone: "baz2", public: true, tags: map[string]string{nameTag: "bar2"}},
+			},
+			false,
+		},
+		{
+			"success-call-filtered",
 			ec2MockOutputs{
 				describeSubnets: R(mockDSOutput(
 					testSubnet{id: "foo1", name: "bar1", az: "baz1", tags: map[string]string{elbRoleTagName: "", clusterIDTagPrefix + "bar": "shared"}},


### PR DESCRIPTION
This fixes #167 by adding a filter when collecting subnet IDs for the manifest structure.