### PR TITLE
Only manage TGs that are owned by the controller

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -314,9 +314,14 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 		return
 	}
 
+	ownerTags := map[string]string{
+		clusterIDTagPrefix + a.ClusterID(): resourceLifecycleOwned,
+		kubernetesCreatorTag:               a.controllerID,
+	}
+
 	for _, asg := range a.autoScalingGroups {
 		// This call is idempotent and safe to execute every time
-		if err := updateTargetGroupsForAutoScalingGroup(a.autoscaling, targetGroupARNs, asg.name); err != nil {
+		if err := updateTargetGroupsForAutoScalingGroup(a.autoscaling, a.elbv2, targetGroupARNs, asg.name, ownerTags); err != nil {
 			log.Printf("UpdateTargetGroupsAndAutoScalingGroups() failed to attach target groups to ASG: %v", err)
 		}
 	}

--- a/aws/asg.go
+++ b/aws/asg.go
@@ -6,6 +6,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 )
 
 type autoScalingGroupDetails struct {
@@ -82,7 +84,7 @@ func getAutoScalingGroupsByName(service autoscalingiface.AutoScalingAPI, autoSca
 	return result, nil
 }
 
-func updateTargetGroupsForAutoScalingGroup(svc autoscalingiface.AutoScalingAPI, targetGroupARNs []string, autoScalingGroupName string) error {
+func updateTargetGroupsForAutoScalingGroup(svc autoscalingiface.AutoScalingAPI, elbv2svc elbv2iface.ELBV2API, targetGroupARNs []string, autoScalingGroupName string, ownerTags map[string]string) error {
 	params := &autoscaling.DescribeLoadBalancerTargetGroupsInput{
 		AutoScalingGroupName: aws.String(autoScalingGroupName),
 	}
@@ -92,10 +94,31 @@ func updateTargetGroupsForAutoScalingGroup(svc autoscalingiface.AutoScalingAPI, 
 		return err
 	}
 
+	arns := make([]*string, 0, len(resp.LoadBalancerTargetGroups))
+	for _, tg := range resp.LoadBalancerTargetGroups {
+		arns = append(arns, tg.LoadBalancerTargetGroupARN)
+	}
+
+	tgParams := &elbv2.DescribeTagsInput{
+		ResourceArns: arns,
+	}
+
+	tgResp, err := elbv2svc.DescribeTags(tgParams)
+	if err != nil {
+		return err
+	}
+
 	// find obsolete target groups which should be detached
 	detachARNs := make([]string, 0, len(targetGroupARNs))
 	for _, tg := range resp.LoadBalancerTargetGroups {
 		tgARN := aws.StringValue(tg.LoadBalancerTargetGroupARN)
+
+		// only consider detaching TGs which are owned by the
+		// controller
+		if !tgHasTags(tgResp.TagDescriptions, tgARN, ownerTags) {
+			continue
+		}
+
 		if !inStrSlice(tgARN, targetGroupARNs) {
 			detachARNs = append(detachARNs, tgARN)
 		}
@@ -118,6 +141,34 @@ func updateTargetGroupsForAutoScalingGroup(svc autoscalingiface.AutoScalingAPI, 
 	}
 
 	return nil
+}
+
+// tgHasTags returns true if the specified resource has the expected tags.
+func tgHasTags(descs []*elbv2.TagDescription, arn string, tags map[string]string) bool {
+	for _, desc := range descs {
+		if aws.StringValue(desc.ResourceArn) == arn && hasTags(desc.Tags, tags) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasTags returns true if the expectedTags are found in the list of tags.
+func hasTags(tags []*elbv2.Tag, expectedTags map[string]string) bool {
+	for key, val := range expectedTags {
+		found := false
+		for _, tag := range tags {
+			if aws.StringValue(tag.Key) == key && aws.StringValue(tag.Value) == val {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func detachTargetGroupsFromAutoScalingGroup(svc autoscalingiface.AutoScalingAPI, targetGroupARNs []string, autoScalingGroupName string) error {

--- a/aws/elbv2mock_test.go
+++ b/aws/elbv2mock_test.go
@@ -8,6 +8,7 @@ import (
 type elbv2MockOutputs struct {
 	registerTargets   *apiResponse
 	deregisterTargets *apiResponse
+	describeTags      *apiResponse
 }
 
 type mockElbv2Client struct {
@@ -35,6 +36,13 @@ func (m *mockElbv2Client) DeregisterTargets(in *elbv2.DeregisterTargetsInput) (*
 		return out, m.outputs.deregisterTargets.err
 	}
 	return nil, m.outputs.deregisterTargets.err
+}
+
+func (m *mockElbv2Client) DescribeTags(tags *elbv2.DescribeTagsInput) (*elbv2.DescribeTagsOutput, error) {
+	if out, ok := m.outputs.describeTags.response.(*elbv2.DescribeTagsOutput); ok {
+		return out, m.outputs.describeTags.err
+	}
+	return nil, m.outputs.describeTags.err
 }
 
 func mockDTOutput() *elbv2.DeregisterTargetsOutput {


### PR DESCRIPTION
This makes sure that the controller only detaches target groups from ASGs when these target groups are managed/owned by the controller. The ownership is determined based on the clusterID and controllerID tags on the target groups.

Fix #165