### PR TITLE
Make maximum number of certificates per ALB configurable

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -73,6 +73,7 @@ const (
 	DefaultStackTTL                  = 5 * time.Minute
 	DefaultIdleConnectionTimeout     = 1 * time.Minute
 	DefaultControllerID              = "kube-ingress-aws-controller"
+	DefaultMaxCertsPerALB            = 25
 
 	nameTag = "Name"
 

--- a/controller.go
+++ b/controller.go
@@ -80,7 +80,7 @@ func loadSettings() error {
 	flag.StringVar(&ingressClassFilters, "ingress-class-filter", "", "optional comma-seperated list of kubernetes.io/ingress.class annotation values to filter behaviour on. ")
 	flag.StringVar(&controllerID, "controller-id", aws.DefaultControllerID, "controller ID used to differentiate resources from multiple aws ingress controller instances")
 	flag.IntVar(&maxCertsPerALB, "max-certs-alb", aws.DefaultMaxCertsPerALB,
-		"sets the maximum number of certificates to be attached to an ALB")
+		fmt.Sprintf("sets the maximum number of certificates to be attached to an ALB. Cannot be higher than %d", aws.DefaultMaxCertsPerALB))
 
 	flag.Parse()
 
@@ -113,6 +113,10 @@ func loadSettings() error {
 			return err
 		}
 		cfCustomTemplate = string(buf)
+	}
+
+	if maxCertsPerALB > aws.DefaultMaxCertsPerALB {
+		return fmt.Errorf("invalid max number of certificates per ALB: %d. AWS does not allow more than %d", maxCertsPerALB, aws.DefaultMaxCertsPerALB)
 	}
 
 	return nil

--- a/controller.go
+++ b/controller.go
@@ -45,6 +45,7 @@ var (
 	idleConnectionTimeout      time.Duration
 	ingressClassFilters        string
 	controllerID               string
+	maxCertsPerALB             int
 )
 
 func loadSettings() error {
@@ -78,6 +79,8 @@ func loadSettings() error {
 	flag.StringVar(&metricsAddress, "metrics-address", ":7979", "defines where to serve metrics")
 	flag.StringVar(&ingressClassFilters, "ingress-class-filter", "", "optional comma-seperated list of kubernetes.io/ingress.class annotation values to filter behaviour on. ")
 	flag.StringVar(&controllerID, "controller-id", aws.DefaultControllerID, "controller ID used to differentiate resources from multiple aws ingress controller instances")
+	flag.IntVar(&maxCertsPerALB, "max-certs-alb", aws.DefaultMaxCertsPerALB,
+		"sets the maximum number of certificates to be attached to an ALB")
 
 	flag.Parse()
 
@@ -197,7 +200,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	certificatesPerALB := maxCertsPerALBSupported
+	certificatesPerALB := maxCertsPerALB
 	if disableSNISupport {
 		certificatesPerALB = 1
 	}

--- a/worker.go
+++ b/worker.go
@@ -38,7 +38,6 @@ const (
 
 const (
 	maxTargetGroupSupported = 1000
-	maxCertsPerALBSupported = 25
 )
 
 func (item *managedItem) Status() int {


### PR DESCRIPTION
The objective of this PR is allowing setting the desired maximum number of certificates to be attached to the ALB with backwards compatibility.

Apart of giving flexibility, allowing to divide the requests among multiple ALBs, it helps to workaround the issue with CloudFormation described in https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/176