### PR TITLE
Pass target port on stack update

### DIFF
--- a/aws/cf.go
+++ b/aws/cf.go
@@ -192,6 +192,7 @@ func updateStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfParam(parameterLoadBalancerSecurityGroupParameter, spec.securityGroupID),
 			cfParam(parameterLoadBalancerSubnetsParameter, strings.Join(spec.subnets, ",")),
 			cfParam(parameterTargetGroupVPCIDParameter, spec.vpcID),
+			cfParam(parameterTargetTargetPortParameter, fmt.Sprintf("%d", spec.targetPort)),
 		},
 		Tags: []*cloudformation.Tag{
 			cfTag(kubernetesCreatorTag, spec.controllerID),


### PR DESCRIPTION
Passes the target port parameter on stack update to ensure it doesn't
get reset to the default value in case a custom value was set by the
user.

Fix #189