### PR TITLE
Update documentation to support IPv6

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,12 +12,21 @@
   [external-dns](https://github.com/kubernetes-incubator/external-dns/)
   to manage DNS records for your Ingress specifications.
 
+## Configuration
+* Update the file ingress-controller.yaml.example following your needs and rename it to ingress-controller.yaml
+* Update the file skipper.yaml.example following your needs and rename it to skipper.yaml
+
 ## Install
 
+    # create a specific service account for skipper and ingress
+    % kubectl apply -f skipper_serviceaccount.yaml
+    % kubectl apply -f ingress-controller.yaml
     # install skipper an ingress http router
     % kubectl create -f deploy/skipper.yaml
     # install the controller which glues together AWS and the ingress implementation
     % kubectl create -f deploy/ingress-controller.yaml
+
+For more information regarding skipper's requirements have a look here [ingress-controller](https://opensource.zalando.com/skipper/kubernetes/ingress-controller/).
 
 If you have done this, you can use our
 [example](https://github.com/zalando-incubator/kube-ingress-aws-controller/tree/master/example)

--- a/deploy/ingress-controller.yaml.example
+++ b/deploy/ingress-controller.yaml.example
@@ -18,10 +18,15 @@ spec:
       labels:
         application: kube-ingress-aws-controller
         component: ingress
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::12345678901:role/YOUR_PRECONFIGURED_ROLE
     spec:
+      serviceAccountName: kube-ingress-aws
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:latest
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.7.4
         env:
         - name: AWS_REGION
-          value: <REGION>
+          value: <REGIOn>
+        args:
+          - "-ip-addr-type=dualstack" OR "-ip-addr-type=ipv4" OR OMIT TO HAVE ipv4

--- a/deploy/ingress-controller.yaml.example
+++ b/deploy/ingress-controller.yaml.example
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: kube-ingress-aws
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.7.4
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:latest
         env:
         - name: AWS_REGION
           value: <REGIOn>

--- a/deploy/ingress-serviceaccount.yaml
+++ b/deploy/ingress-serviceaccount.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ingress-aws
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: ingress-controller
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  - ingresses
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-controller
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system
+- kind: ServiceAccount
+  name: default
+  namespace: default
+- kind: ServiceAccount
+  name: kube-ingress-aws
+  namespace: kube-system
+

--- a/deploy/requirements.md
+++ b/deploy/requirements.md
@@ -29,210 +29,256 @@ Please also note that the worker nodes will need the right permission to describ
 
 ```
 {
-    "Action": "autoscaling:DescribeAutoScalingGroups",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "autoscaling:AttachLoadBalancers",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "autoscaling:DetachLoadBalancers",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "autoscaling:DetachLoadBalancerTargetGroups",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "autoscaling:AttachLoadBalancerTargetGroups",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "autoscaling:DescribeLoadBalancerTargetGroups",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:DescribeLoadBalancers",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:CreateLoadBalancer",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:DeleteLoadBalancer",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:DescribeListeners",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:CreateListener",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:DeleteListener",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:DescribeTags",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:CreateTargetGroup",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:DeleteTargetGroup",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancing:DescribeTargetGroups",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:DescribeTargetGroups",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:DescribeLoadBalancers",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:CreateLoadBalancer",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:DeleteLoadBalancer",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:DescribeListeners",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:CreateListener",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:DeleteListener",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:DescribeTags",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:CreateTargetGroup",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "elasticloadbalancingv2:DeleteTargetGroup",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "ec2:DescribeInstances",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "ec2:DescribeSubnets",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "ec2:DescribeSecurityGroups",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "ec2:DescribeRouteTables",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "ec2:DescribeVpcs",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "acm:ListCertificates",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "acm:GetCertificate",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "iam:ListServerCertificates",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "iam:GetServerCertificate",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "cloudformation:Get*",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "cloudformation:Describe*",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "cloudformation:List*",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "cloudformation:Create*",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "cloudformation:Update*",
-    "Resource": "*",
-    "Effect": "Allow"
-},
-{
-    "Action": "cloudformation:Delete*",
-    "Resource": "*",
-    "Effect": "Allow"
+"Version": "2012-10-17",
+"Statement": [
+    {
+        "Action": "autoscaling:DescribeAutoScalingGroups",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "autoscaling:AttachLoadBalancers",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "autoscaling:DetachLoadBalancers",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "autoscaling:DetachLoadBalancerTargetGroups",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "autoscaling:AttachLoadBalancerTargetGroups",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "autoscaling:DescribeLoadBalancerTargetGroups",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DescribeLoadBalancers",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:CreateLoadBalancer",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DeleteLoadBalancer",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DescribeListeners",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:CreateListener",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DeleteListener",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DescribeTags",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:CreateTargetGroup",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DeleteTargetGroup",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DescribeTargetGroups",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DescribeTargetGroups",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DescribeLoadBalancers",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:CreateLoadBalancer",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DeleteLoadBalancer",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DescribeListeners",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:CreateListener",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DeleteListener",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DescribeTags",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:CreateTargetGroup",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DeleteTargetGroup",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:AddTags",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:RemoveListenerCertificates",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:AddListenerCertificates",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:DescribeListenerCertificates",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:ModifyTargetGroup",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:RemoveTags",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "elasticloadbalancing:ModifyListener",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "ec2:DescribeInstances",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "ec2:DescribeSubnets",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "ec2:DescribeSecurityGroups",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "ec2:DescribeRouteTables",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "ec2:DescribeVpcs",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "acm:ListCertificates",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "acm:DescribeCertificate",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "iam:ListServerCertificates",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "iam:GetServerCertificate",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "cloudformation:Get*",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "cloudformation:Describe*",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "cloudformation:List*",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "cloudformation:Create*",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "cloudformation:Update*",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
+        "Action": "cloudformation:Delete*",
+        "Resource": "*",
+        "Effect": "Allow"
+    }
+]
 }
+
 ```
 
 The decision of how to grant these roles is out of scope for this document and depends on your setup. Possible options are:

--- a/deploy/skipper.yaml.example
+++ b/deploy/skipper.yaml.example
@@ -16,15 +16,19 @@ spec:
       name: skipper-ingress
       labels:
         component: ingress
+        application: skipper
     spec:
       hostNetwork: true
+      serviceAccountName: skipper-ingress
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:latest
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.70
         ports:
         - name: ingress-port
           containerPort: 9999
           hostPort: 9999
+        - name: metrics-port
+          containerPort: 9911
         args:
           - "skipper"
           - "-kubernetes"
@@ -35,14 +39,13 @@ spec:
           - "-enable-ratelimits"
           - "-experimental-upgrade"
           - "-metrics-exp-decay-sample"
-          - "-kubernetes-https-redirect=true"
+          - "-lb-healthcheck-interval=3s"
+          - "-metrics-flavour=codahale,prometheus"
+          - "-enable-connection-metrics"
         resources:
-          limits:
+          requests:
             cpu: 200m
             memory: 200Mi
-          requests:
-            cpu: 25m
-            memory: 25Mi
         readinessProbe:
           httpGet:
             path: /kube-system/healthz

--- a/deploy/skipper.yaml.example
+++ b/deploy/skipper.yaml.example
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: skipper-ingress
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.70
+        image: registry.opensource.zalan.do/pathfinder/skipper:latest
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/deploy/skipper_serviceaccount.yaml
+++ b/deploy/skipper_serviceaccount.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skipper-ingress
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: skipper-ingress
+rules:
+- apiGroups: ["extensions"]
+  resources: ["ingresses", ]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["namespaces", "services", "endpoints"]
+  verbs: ["get"]
+
+--- 
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: skipper-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: skipper-ingress
+subjects:
+- kind: ServiceAccount
+  name: skipper-ingress
+  namespace: kube-system


### PR DESCRIPTION
Following Bug https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/182
Update docs to reflect how to use IPv6
Add RBAC rules to run properly the skipper and the ingress-controller
Update wrong elasticloadbalancingv2 policy rules