### PR TITLE
fix #220, use correct controllerID looking up SGs

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -130,7 +130,7 @@ func defaultConfigProvider() client.ConfigProvider {
 // Before returning there is a discovery process for VPC and EC2 details. It tries to find the Auto Scaling Group and
 // Security Group that should be used for newly created Load Balancers. If any of those critical steps fail
 // an appropriate error is returned.
-func NewAdapter() (adapter *Adapter, err error) {
+func NewAdapter(newControllerID string) (adapter *Adapter, err error) {
 	p := configProvider()
 	adapter = &Adapter{
 		ec2:                 ec2.New(p),
@@ -150,7 +150,7 @@ func NewAdapter() (adapter *Adapter, err error) {
 		ec2Details:          make(map[string]*instanceDetails),
 		singleInstances:     make(map[string]*instanceDetails),
 		obsoleteInstances:   make([]string, 0),
-		controllerID:        DefaultControllerID,
+		controllerID:        newControllerID,
 		sslPolicy:           DefaultSslPolicy,
 		ipAddressType:       DefaultIpAddressType,
 	}
@@ -479,7 +479,7 @@ func buildManifest(awsAdapter *Adapter) (*manifest, error) {
 
 	clusterID := instanceDetails.clusterID()
 
-	securityGroupDetails, err := findSecurityGroupWithClusterID(awsAdapter.ec2, clusterID)
+	securityGroupDetails, err := findSecurityGroupWithClusterID(awsAdapter.ec2, clusterID, awsAdapter.controllerID)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -278,7 +278,7 @@ func isSubnetPublic(rt []*ec2.RouteTable, subnetID string) (bool, error) {
 	return false, nil
 }
 
-func findSecurityGroupWithClusterID(svc ec2iface.EC2API, clusterID string) (*securityGroupDetails, error) {
+func findSecurityGroupWithClusterID(svc ec2iface.EC2API, clusterID string, controllerID string) (*securityGroupDetails, error) {
 	params := &ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -302,7 +302,7 @@ func findSecurityGroupWithClusterID(svc ec2iface.EC2API, clusterID string) (*sec
 			{
 				Name: aws.String("tag-value"),
 				Values: []*string{
-					aws.String(DefaultControllerID),
+					aws.String(controllerID),
 				},
 			},
 		},

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -54,7 +54,7 @@ func TestFindingSecurityGroup(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%v", test.name), func(t *testing.T) {
 			ec2 := &mockEc2Client{outputs: test.responses}
-			got, err := findSecurityGroupWithClusterID(ec2, "foo")
+			got, err := findSecurityGroupWithClusterID(ec2, "foo", "kube-ingress-aws-controller")
 			assertResultAndError(t, test.want, got, test.wantError, err)
 		})
 	}

--- a/controller.go
+++ b/controller.go
@@ -184,7 +184,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	awsAdapter, err = aws.NewAdapter()
+	awsAdapter, err = aws.NewAdapter(controllerID)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This went a little deeper than initially expected, owing to the fact that where buildManifest was being called (and where the SGs are ultimately looked up), was *prior* to the application of the collected flag values to the awsAdapter.

So I've moved the manifest to something similar to the With*() functions, and apply it in the same way *after* we have the flags applied to the awsAdapter. Let me know if you'd like to see this handled differently?

I had not previously seen this, as I had always been running an instance with the default controllerID (and so had a SG of that name around to be successfully looked up). It's only recently that has been absent, and exposed this bug.