### PR TITLE
Enable ALB logging to S3 via new flags

### DIFF
--- a/aws/cf.go
+++ b/aws/cf.go
@@ -126,6 +126,8 @@ type stackSpec struct {
 	controllerID                 string
 	sslPolicy                    string
 	ipAddressType                string
+	albLogsS3Bucket              string
+	albLogsS3Prefix              string
 }
 
 type healthCheck struct {
@@ -135,7 +137,7 @@ type healthCheck struct {
 }
 
 func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (string, error) {
-	template, err := generateTemplate(spec.certificateARNs, spec.idleConnectionTimeoutSeconds)
+	template, err := generateTemplate(spec.certificateARNs, spec.idleConnectionTimeoutSeconds, spec.albLogsS3Bucket, spec.albLogsS3Prefix)
 	if err != nil {
 		return "", err
 	}
@@ -186,7 +188,7 @@ func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 }
 
 func updateStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (string, error) {
-	template, err := generateTemplate(spec.certificateARNs, spec.idleConnectionTimeoutSeconds)
+	template, err := generateTemplate(spec.certificateARNs, spec.idleConnectionTimeoutSeconds, spec.albLogsS3Bucket, spec.albLogsS3Prefix)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Two new flags have been implemented:

  --logs-s3-bucket <name of s3 bucket>
  --logs-s3-prefix <path prefix within s3 bucket>

Setting the bucket will enable logging support, not setting it will
leave it disabled. The prefix setting will only take effect if the
bucket is also set.

This should satisfy the feature request in #201 