### PR TITLE
docs: fix policy

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,6 +13,7 @@
   to manage DNS records for your Ingress specifications.
 
 ## Configuration
+
 * Update the file ingress-controller.yaml.example following your needs and rename it to ingress-controller.yaml
 * Update the file skipper.yaml.example following your needs and rename it to skipper.yaml
 

--- a/deploy/requirements.md
+++ b/deploy/requirements.md
@@ -227,6 +227,11 @@ Please also note that the worker nodes will need the right permission to describ
         "Effect": "Allow"
     },
     {
+        "Action": "acm:Getertificate",
+        "Resource": "*",
+        "Effect": "Allow"
+    },
+    {
         "Action": "acm:ListCertificates",
         "Resource": "*",
         "Effect": "Allow"


### PR DESCRIPTION
docs fix https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/213 update kops docs to match the policy that was stated

docs fix requirements.md to match our current deployment https://github.com/zalando-incubator/kubernetes-on-aws/blob/dev/cluster/cluster.yaml#L655-L717

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>