### PR TITLE
Fix aws-sdk-go & testify dependencies

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "~1.13.6"
+  version = "^1.13.6"
 
 [[constraint]]
   name = "github.com/google/uuid"
@@ -51,7 +51,7 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "~1.2.2"
+  version = "^1.2.2"
 
 [prune]
   go-tests = true


### PR DESCRIPTION
They both follow semver, so `~` is unnecessarily restrictive.