### PR TITLE
#164 Added impl that provide waf id and create cf with waf association

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -58,6 +58,7 @@ type Adapter struct {
 	ipAddressType              string
 	albLogsS3Bucket            string
 	albLogsS3Prefix            string
+	wafWebAclId                string
 }
 
 type manifest struct {
@@ -94,6 +95,7 @@ const (
 	DefaultAlbS3LogsBucket = ""
 	// Default ALB logging S3 prefix is a blank string, and optionally set if desired
 	DefaultAlbS3LogsPrefix = ""
+	DefaultWafWebAclId     = ""
 
 	ipAddressTypeDualstack = "dualstack"
 	nameTag                = "Name"
@@ -161,6 +163,7 @@ func NewAdapter(newControllerID string) (adapter *Adapter, err error) {
 		ipAddressType:       DefaultIpAddressType,
 		albLogsS3Bucket:     DefaultAlbS3LogsBucket,
 		albLogsS3Prefix:     DefaultAlbS3LogsPrefix,
+		wafWebAclId:         DefaultWafWebAclId,
 	}
 
 	adapter.manifest, err = buildManifest(adapter)
@@ -271,6 +274,12 @@ func (a *Adapter) WithAlbLogsS3Bucket(bucket string) *Adapter {
 // WithAlbLogsS3Bucket returns the receiver adapter after changing the S3 prefix within the bucket for logging
 func (a *Adapter) WithAlbLogsS3Prefix(prefix string) *Adapter {
 	a.albLogsS3Prefix = prefix
+	return a
+}
+
+// WithWafWebAclId returns the receiver adapter after changing the waf web acl id for waf association
+func (a *Adapter) WithWafWebAclId(wafWebAclId string) *Adapter {
+	a.wafWebAclId = wafWebAclId
 	return a
 }
 
@@ -446,6 +455,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 		ipAddressType:                a.ipAddressType,
 		albLogsS3Bucket:              a.albLogsS3Bucket,
 		albLogsS3Prefix:              a.albLogsS3Prefix,
+		wafWebAclId:                  a.wafWebAclId,
 	}
 
 	return createStack(a.cloudformation, spec)
@@ -474,6 +484,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 		ipAddressType:                a.ipAddressType,
 		albLogsS3Bucket:              a.albLogsS3Bucket,
 		albLogsS3Prefix:              a.albLogsS3Prefix,
+		wafWebAclId:                  a.wafWebAclId,
 	}
 
 	return updateStack(a.cloudformation, spec)

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -129,6 +129,7 @@ type stackSpec struct {
 	ipAddressType                string
 	albLogsS3Bucket              string
 	albLogsS3Prefix              string
+	wafWebAclId                  string
 }
 
 type healthCheck struct {
@@ -138,7 +139,7 @@ type healthCheck struct {
 }
 
 func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (string, error) {
-	template, err := generateTemplate(spec.certificateARNs, spec.idleConnectionTimeoutSeconds, spec.albLogsS3Bucket, spec.albLogsS3Prefix)
+	template, err := generateTemplate(spec.certificateARNs, spec.idleConnectionTimeoutSeconds, spec.albLogsS3Bucket, spec.albLogsS3Prefix, spec.wafWebAclId)
 	if err != nil {
 		return "", err
 	}
@@ -189,7 +190,7 @@ func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 }
 
 func updateStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (string, error) {
-	template, err := generateTemplate(spec.certificateARNs, spec.idleConnectionTimeoutSeconds, spec.albLogsS3Bucket, spec.albLogsS3Prefix)
+	template, err := generateTemplate(spec.certificateARNs, spec.idleConnectionTimeoutSeconds, spec.albLogsS3Bucket, spec.albLogsS3Prefix, spec.wafWebAclId)
 	if err != nil {
 		return "", err
 	}

--- a/controller.go
+++ b/controller.go
@@ -56,6 +56,7 @@ var (
 	ipAddressType              string
 	albLogsS3Bucket            string
 	albLogsS3Prefix            string
+	wafWebAclId                string
 )
 
 func loadSettings() error {
@@ -98,6 +99,7 @@ func loadSettings() error {
 	flag.StringVar(&ipAddressType, "ip-addr-type", aws.DefaultIpAddressType, "IP Address type to use, one of 'ipv4' or 'dualstack'")
 	flag.StringVar(&albLogsS3Bucket, "logs-s3-bucket", aws.DefaultAlbS3LogsBucket, "S3 bucket to be used for ALB logging")
 	flag.StringVar(&albLogsS3Prefix, "logs-s3-prefix", aws.DefaultAlbS3LogsPrefix, "Prefix within S3 bucket to be used for ALB logging")
+	flag.StringVar(&wafWebAclId, "aws-waf-web-acl-id", aws.DefaultWafWebAclId, "Waf web acl id to be associated with the ALB")
 
 	flag.Parse()
 
@@ -205,7 +207,8 @@ func main() {
 		WithSslPolicy(sslPolicy).
 		WithIpAddressType(ipAddressType).
 		WithAlbLogsS3Bucket(albLogsS3Bucket).
-		WithAlbLogsS3Prefix(albLogsS3Prefix)
+		WithAlbLogsS3Prefix(albLogsS3Prefix).
+		WithWafWebAclId(wafWebAclId)
 
 	certificatesProvider, err := certs.NewCachingProvider(
 		certPollingInterval,


### PR DESCRIPTION
Added parameter `aws-waf-web-acl-id` (it must be the waf hash id, not the name) that when it is provided it will create an cludformation template with an WafAssociation

It will require the policies:

- waf-regional:AssociateWebACL
- waf-regional:DisassociateWebACL
- elasticloadbalancing:SetWebACL

Known issue, It won't disassociate in case of removal to any wafid

