### PR TITLE
Add support for Network Load Balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This information is used to manage AWS resources for each ingress objects of the
 - Automatic discovery of SSL certificates
 - Automatic forwarding of requests to all Worker Nodes, even with auto scaling
 - Automatic cleanup of unnecessary managed resources
+- Support for both [Application Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) and [Network Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html).
 - Support for internet-facing and internal load balancers
 - Support for multiple Auto Scaling Groups
 - Support for instances that are not part of Auto Scaling Group
@@ -84,15 +85,18 @@ running has the clusterID tag `kubernetes.io/cluster/<cluster-id>=owned` set
 Overview of annotations which can be set.
 
 ### Annotations
-|Name                       | Type |Default
+|Name                       | Value |Default
 |---------------------------|------|------|
-|[alb.ingress.kubernetes.io/ip-address-type](#ip-address-type)|ipv4 \| dualstack|ipv4|
-|zalando.org/aws-load-balancer-ssl-cert|string|N/A|
-|zalando.org/aws-load-balancer-scheme|internal \| internet-facing |internet-facing|
-|zalando.org/aws-load-balancer-shared|true \| false|false|
-|zalando.org/aws-load-balancer-security-group|string|N/A|
-|zalando.org/aws-load-balancer-ssl-policy|string|ELBSecurityPolicy-2016-08|
-|kubernetes.io/ingress.class|string|N/A|
+|[`alb.ingress.kubernetes.io/ip-address-type`](#ip-address-type)|`ipv4` \| `dualstack` |`ipv4`|
+|`zalando.org/aws-load-balancer-ssl-cert`|`string`|N/A|
+|`zalando.org/aws-load-balancer-scheme`|`internal` \| `internet-facing` |`internet-facing`|
+|`zalando.org/aws-load-balancer-shared`|`true` \| `false`|`false`|
+|`zalando.org/aws-load-balancer-security-group`|`string`|N/A|
+|`zalando.org/aws-load-balancer-ssl-policy`|`string`|`ELBSecurityPolicy-2016-08`|
+|`zalando.org/aws-load-balancer-type`| `nlb` \| `alb`|`alb`|
+|`kubernetes.io/ingress.class`|`string`|N/A|
+
+The defaults can also be configured globally via a flag on the controller.
 
 ## AWS Tags
 

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -54,6 +54,7 @@ type Adapter struct {
 	controllerID               string
 	sslPolicy                  string
 	ipAddressType              string
+	loadbalancerType           string
 	albLogsS3Bucket            string
 	albLogsS3Prefix            string
 	wafWebAclId                string
@@ -92,6 +93,8 @@ const (
 	DefaultSslPolicy = "ELBSecurityPolicy-2016-08"
 	// DefaultIpAddressType sets IpAddressType to "ipv4", it is either ipv4 or dualstack
 	DefaultIpAddressType = "ipv4"
+	// DefaultLoadbalancerType is the default Type of a AWS::ElasticLoadBalancingV2::LoadBalancer "application" or "network"
+	DefaultLoadbalancerType = "application"
 	// DefaultAlbS3LogsBucket is a blank string, and must be set if enabled
 	DefaultAlbS3LogsBucket = ""
 	// DefaultAlbS3LogsPrefix is a blank string, and optionally set if desired
@@ -170,6 +173,7 @@ func NewAdapter(newControllerID string) (adapter *Adapter, err error) {
 		controllerID:        newControllerID,
 		sslPolicy:           DefaultSslPolicy,
 		ipAddressType:       DefaultIpAddressType,
+		loadbalancerType:    DefaultLoadbalancerType,
 		albLogsS3Bucket:     DefaultAlbS3LogsBucket,
 		albLogsS3Prefix:     DefaultAlbS3LogsPrefix,
 		wafWebAclId:         DefaultWafWebAclId,
@@ -488,6 +492,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 		controllerID:                 a.controllerID,
 		sslPolicy:                    sslPolicy,
 		ipAddressType:                ipAddressType,
+		loadbalancerType:             a.loadbalancerType, // TODO(sszuecs): make this configurable
 		albLogsS3Bucket:              a.albLogsS3Bucket,
 		albLogsS3Prefix:              a.albLogsS3Prefix,
 		wafWebAclId:                  a.wafWebAclId,
@@ -523,6 +528,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 		controllerID:                 a.controllerID,
 		sslPolicy:                    sslPolicy,
 		ipAddressType:                ipAddressType,
+		loadbalancerType:             a.loadbalancerType, // TODO(sszuecs): make this configurable
 		albLogsS3Bucket:              a.albLogsS3Bucket,
 		albLogsS3Prefix:              a.albLogsS3Prefix,
 		wafWebAclId:                  a.wafWebAclId,

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -54,7 +54,6 @@ type Adapter struct {
 	controllerID               string
 	sslPolicy                  string
 	ipAddressType              string
-	loadbalancerType           string
 	albLogsS3Bucket            string
 	albLogsS3Prefix            string
 	wafWebAclId                string
@@ -93,8 +92,8 @@ const (
 	DefaultSslPolicy = "ELBSecurityPolicy-2016-08"
 	// DefaultIpAddressType sets IpAddressType to "ipv4", it is either ipv4 or dualstack
 	DefaultIpAddressType = "ipv4"
-	// DefaultLoadbalancerType is the default Type of a AWS::ElasticLoadBalancingV2::LoadBalancer "application" or "network"
-	DefaultLoadbalancerType = "application"
+	// DefaultLoadBalancerType is the default Type of a AWS::ElasticLoadBalancingV2::LoadBalancer "application" or "network"
+	DefaultLoadBalancerType = "application"
 	// DefaultAlbS3LogsBucket is a blank string, and must be set if enabled
 	DefaultAlbS3LogsBucket = ""
 	// DefaultAlbS3LogsPrefix is a blank string, and optionally set if desired
@@ -173,7 +172,6 @@ func NewAdapter(newControllerID string) (adapter *Adapter, err error) {
 		controllerID:        newControllerID,
 		sslPolicy:           DefaultSslPolicy,
 		ipAddressType:       DefaultIpAddressType,
-		loadbalancerType:    DefaultLoadbalancerType,
 		albLogsS3Bucket:     DefaultAlbS3LogsBucket,
 		albLogsS3Prefix:     DefaultAlbS3LogsPrefix,
 		wafWebAclId:         DefaultWafWebAclId,
@@ -457,7 +455,7 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 // All the required resources (listeners and target group) are created in a
 // transactional fashion.
 // Failure to create the stack causes it to be deleted automatically.
-func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, owner, sslPolicy, ipAddressType string, cwAlarms CloudWatchAlarmList) (string, error) {
+func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, owner, sslPolicy, ipAddressType string, cwAlarms CloudWatchAlarmList, loadBalancerType string) (string, error) {
 	certARNs := make(map[string]time.Time, len(certificateARNs))
 	for _, arn := range certificateARNs {
 		certARNs[arn] = time.Time{}
@@ -492,7 +490,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 		controllerID:                 a.controllerID,
 		sslPolicy:                    sslPolicy,
 		ipAddressType:                ipAddressType,
-		loadbalancerType:             a.loadbalancerType, // TODO(sszuecs): make this configurable
+		loadbalancerType:             loadBalancerType,
 		albLogsS3Bucket:              a.albLogsS3Bucket,
 		albLogsS3Prefix:              a.albLogsS3Prefix,
 		wafWebAclId:                  a.wafWebAclId,
@@ -503,7 +501,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 	return createStack(a.cloudformation, spec)
 }
 
-func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.Time, scheme, sslPolicy, ipAddressType string, cwAlarms CloudWatchAlarmList) (string, error) {
+func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.Time, scheme, sslPolicy, ipAddressType string, cwAlarms CloudWatchAlarmList, loadBalancerType string) (string, error) {
 	if _, ok := SSLPolicies[sslPolicy]; !ok {
 		return "", fmt.Errorf("invalid SSLPolicy '%s' defined", sslPolicy)
 	}
@@ -528,7 +526,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 		controllerID:                 a.controllerID,
 		sslPolicy:                    sslPolicy,
 		ipAddressType:                ipAddressType,
-		loadbalancerType:             a.loadbalancerType, // TODO(sszuecs): make this configurable
+		loadbalancerType:             loadBalancerType,
 		albLogsS3Bucket:              a.albLogsS3Bucket,
 		albLogsS3Prefix:              a.albLogsS3Prefix,
 		wafWebAclId:                  a.wafWebAclId,

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -26,6 +26,7 @@ type Stack struct {
 	SecurityGroup     string
 	SSLPolicy         string
 	IpAddressType     string
+	LoadBalancerType  string
 	OwnerIngress      string
 	CWAlarmConfigHash string
 	TargetGroupARN    string
@@ -364,6 +365,7 @@ func mapToManagedStack(stack *cloudformation.Stack) *Stack {
 		SecurityGroup:     parameters[parameterLoadBalancerSecurityGroupParameter],
 		SSLPolicy:         parameters[parameterListenerSslPolicyParameter],
 		IpAddressType:     parameters[parameterIpAddressTypeParameter],
+		LoadBalancerType:  parameters[parameterLoadBalancerTypeParameter],
 		CertificateARNs:   certificateARNs,
 		tags:              tags,
 		OwnerIngress:      ownerIngress,

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -138,6 +138,7 @@ type stackSpec struct {
 	wafWebAclId                  string
 	cwAlarms                     CloudWatchAlarmList
 	httpRedirectToHttps          bool
+	nlbCrossZone                 bool
 }
 
 type healthCheck struct {

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -110,6 +110,7 @@ const (
 	parameterListenerCertificatesParameter           = "ListenerCertificatesParameter"
 	parameterListenerSslPolicyParameter              = "ListenerSslPolicyParameter"
 	parameterIpAddressTypeParameter                  = "IpAddressType"
+	parameterLoadBalancerTypeParameter               = "Type"
 )
 
 type stackSpec struct {
@@ -130,6 +131,7 @@ type stackSpec struct {
 	controllerID                 string
 	sslPolicy                    string
 	ipAddressType                string
+	loadbalancerType             string
 	albLogsS3Bucket              string
 	albLogsS3Prefix              string
 	wafWebAclId                  string
@@ -160,6 +162,7 @@ func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfParam(parameterTargetTargetPortParameter, fmt.Sprintf("%d", spec.targetPort)),
 			cfParam(parameterListenerSslPolicyParameter, spec.sslPolicy),
 			cfParam(parameterIpAddressTypeParameter, spec.ipAddressType),
+			cfParam(parameterLoadBalancerTypeParameter, spec.loadbalancerType),
 		},
 		Tags: []*cloudformation.Tag{
 			cfTag(kubernetesCreatorTag, spec.controllerID),
@@ -214,6 +217,7 @@ func updateStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfParam(parameterTargetTargetPortParameter, fmt.Sprintf("%d", spec.targetPort)),
 			cfParam(parameterListenerSslPolicyParameter, spec.sslPolicy),
 			cfParam(parameterIpAddressTypeParameter, spec.ipAddressType),
+			cfParam(parameterLoadBalancerTypeParameter, spec.loadbalancerType),
 		},
 		Tags: []*cloudformation.Tag{
 			cfTag(kubernetesCreatorTag, spec.controllerID),

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -70,16 +70,23 @@ func generateTemplate(spec *stackSpec) (string, error) {
 		parameterIpAddressTypeParameter: &cloudformation.Parameter{
 			Type:        "String",
 			Description: "IP Address Type, 'ipv4' or 'dualstack'",
-			Default:     "ipv4",
+			Default:     IPAddressTypeIPV4,
 		},
 		parameterLoadBalancerTypeParameter: &cloudformation.Parameter{
 			Type:        "String",
 			Description: "Loadbalancer Type, 'application' or 'network'",
-			Default:     "application",
+			Default:     LoadBalancerTypeApplication,
 		},
 	}
 
-	if spec.httpRedirectToHttps {
+	protocol := "HTTP"
+	tlsProtocol := "HTTPS"
+	if spec.loadbalancerType == LoadBalancerTypeNetwork {
+		protocol = "TCP"
+		tlsProtocol = "TLS"
+	}
+
+	if spec.loadbalancerType == LoadBalancerTypeApplication && spec.httpRedirectToHttps {
 		template.AddResource("HTTPListener", &cloudformation.ElasticLoadBalancingV2Listener{
 			DefaultActions: &cloudformation.ElasticLoadBalancingV2ListenerActionList{
 				{
@@ -108,7 +115,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 			},
 			LoadBalancerArn: cloudformation.Ref("LB").String(),
 			Port:            cloudformation.Integer(80),
-			Protocol:        cloudformation.String("HTTP"),
+			Protocol:        cloudformation.String(protocol),
 		})
 	}
 
@@ -137,7 +144,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 			},
 			LoadBalancerArn: cloudformation.Ref("LB").String(),
 			Port:            cloudformation.Integer(443),
-			Protocol:        cloudformation.String("HTTPS"),
+			Protocol:        cloudformation.String(tlsProtocol),
 			SslPolicy:       cloudformation.Ref(parameterListenerSslPolicyParameter).String(),
 		})
 
@@ -160,12 +167,25 @@ func generateTemplate(spec *stackSpec) (string, error) {
 
 	// Build up the LoadBalancerAttributes list, as there is no way to make attributes conditional in the template
 	albAttrList := make(cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttributeList, 0, 4)
-	albAttrList = append(albAttrList,
-		cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute{
-			Key:   cloudformation.String("idle_timeout.timeout_seconds"),
-			Value: cloudformation.String(fmt.Sprintf("%d", spec.idleConnectionTimeoutSeconds)),
-		},
-	)
+
+	if spec.loadbalancerType == LoadBalancerTypeApplication {
+		albAttrList = append(albAttrList,
+			cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute{
+				Key:   cloudformation.String("idle_timeout.timeout_seconds"),
+				Value: cloudformation.String(fmt.Sprintf("%d", spec.idleConnectionTimeoutSeconds)),
+			},
+		)
+	}
+
+	if spec.nlbCrossZone && spec.loadbalancerType == LoadBalancerTypeNetwork {
+		albAttrList = append(albAttrList,
+			cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute{
+				Key:   cloudformation.String("load_balancing.cross_zone.enabled"),
+				Value: cloudformation.String("true"),
+			},
+		)
+	}
+
 	if spec.albLogsS3Bucket != "" {
 		albAttrList = append(albAttrList,
 			cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute{
@@ -199,10 +219,9 @@ func generateTemplate(spec *stackSpec) (string, error) {
 	lb := &cloudformation.ElasticLoadBalancingV2LoadBalancer{
 		LoadBalancerAttributes: &albAttrList,
 
-		IPAddressType:  cloudformation.Ref(parameterIpAddressTypeParameter).String(),
-		Scheme:         cloudformation.Ref(parameterLoadBalancerSchemeParameter).String(),
-		SecurityGroups: cloudformation.Ref(parameterLoadBalancerSecurityGroupParameter).StringList(),
-		Subnets:        cloudformation.Ref(parameterLoadBalancerSubnetsParameter).StringList(),
+		IPAddressType: cloudformation.Ref(parameterIpAddressTypeParameter).String(),
+		Scheme:        cloudformation.Ref(parameterLoadBalancerSchemeParameter).String(),
+		Subnets:       cloudformation.Ref(parameterLoadBalancerSubnetsParameter).StringList(),
 		Tags: &cloudformation.TagList{
 			{
 				Key:   cloudformation.String("StackName"),
@@ -211,12 +230,17 @@ func generateTemplate(spec *stackSpec) (string, error) {
 		},
 	}
 
+	// Security groups can't be set for 'network' load balancers
+	if spec.loadbalancerType != LoadBalancerTypeNetwork {
+		lb.SecurityGroups = cloudformation.Ref(parameterLoadBalancerSecurityGroupParameter).StringList()
+	}
+
 	// TODO(mlarsen): hack to only set type on "new" stacks where this
 	// features was enabled. Adding the Type value for existing Load
 	// Balancers will cause them to be recreated which is disruptive (and
 	// breaks because AWS tries to attach the same TG to multiple LBs).
 	// Can be removed in a later version.
-	if spec.loadbalancerType == "application" || spec.loadbalancerType == "network" {
+	if spec.loadbalancerType == LoadBalancerTypeApplication || spec.loadbalancerType == LoadBalancerTypeNetwork {
 		lb.Type = cloudformation.Ref(parameterLoadBalancerTypeParameter).String()
 	}
 
@@ -225,12 +249,13 @@ func generateTemplate(spec *stackSpec) (string, error) {
 		HealthCheckIntervalSeconds: cloudformation.Ref(parameterTargetGroupHealthCheckIntervalParameter).Integer(),
 		HealthCheckPath:            cloudformation.Ref(parameterTargetGroupHealthCheckPathParameter).String(),
 		HealthCheckPort:            cloudformation.Ref(parameterTargetGroupHealthCheckPortParameter).String(),
+		HealthCheckProtocol:        cloudformation.String("HTTP"),
 		Port:                       cloudformation.Ref(parameterTargetTargetPortParameter).Integer(),
-		Protocol:                   cloudformation.String("HTTP"),
+		Protocol:                   cloudformation.String(protocol),
 		VPCID:                      cloudformation.Ref(parameterTargetGroupVPCIDParameter).String(),
 	})
 
-	if spec.wafWebAclId != "" {
+	if spec.loadbalancerType == LoadBalancerTypeApplication && spec.wafWebAclId != "" {
 		template.AddResource("WAFAssociation", &cloudformation.WAFRegionalWebACLAssociation{
 			ResourceArn: cloudformation.Ref("LB").String(),
 			WebACLID:    cloudformation.String(spec.wafWebAclId),

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -72,6 +72,11 @@ func generateTemplate(spec *stackSpec) (string, error) {
 			Description: "IP Address Type, 'ipv4' or 'dualstack'",
 			Default:     "ipv4",
 		},
+		parameterLoadBalancerTypeParameter: &cloudformation.Parameter{
+			Type:        "String",
+			Description: "Loadbalancer Type, 'application' or 'network'",
+			Default:     "application",
+		},
 	}
 
 	if spec.httpRedirectToHttps {
@@ -204,6 +209,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 				Value: cloudformation.Ref("AWS::StackName").String(),
 			},
 		},
+		Type: cloudformation.Ref(parameterLoadBalancerTypeParameter).String(),
 	})
 	template.AddResource("TG", &cloudformation.ElasticLoadBalancingV2TargetGroup{
 		HealthCheckIntervalSeconds: cloudformation.Ref(parameterTargetGroupHealthCheckIntervalParameter).Integer(),

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -142,8 +142,10 @@ func (a *Adapter) newIngressFromKube(kubeIngress *ingress) *Ingress {
 		sslPolicy = a.ingressDefaultSSLPolicy
 	}
 
-	// TODO: validate teh value
 	loadBalancerType := kubeIngress.getAnnotationsString(ingressLoadBalancerTypeAnnotation, a.ingressDefaultLoadBalancerType)
+	if _, ok := loadBalancerTypesIngressToAWS[loadBalancerType]; !ok {
+		loadBalancerType = a.ingressDefaultLoadBalancerType
+	}
 
 	// convert to the internal naming e.g. nlb -> network
 	loadBalancerType = loadBalancerTypesIngressToAWS[loadBalancerType]

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -22,7 +22,8 @@ var (
 	testSSLPolicy                   = "ELBSecurityPolicy-TLS-1-2-2017-01"
 	testIPAddressTypeDualStack      = aws.IPAddressTypeDualstack
 	testIPAddressTypeDefault        = aws.IPAddressTypeIPV4
-	testLoadBalancerType            = aws.LoadBalancerTypeApplication
+	testLoadBalancerTypeIngress     = loadBalancerTypeALB
+	testLoadBalancerTypeAWS         = aws.LoadBalancerTypeApplication
 )
 
 func TestMappingRoundtrip(tt *testing.T) {
@@ -44,7 +45,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 				SecurityGroup:    testSecurityGroup,
 				SSLPolicy:        testSSLPolicy,
 				IPAddressType:    testIPAddressTypeDefault,
-				LoadBalancerType: testLoadBalancerType,
+				LoadBalancerType: testLoadBalancerTypeAWS,
 			},
 			kubeIngress: &ingress{
 				Metadata: ingressItemMetadata{
@@ -57,7 +58,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 						ingressSecurityGroupAnnotation:    testSecurityGroup,
 						ingressSSLPolicyAnnotation:        testSSLPolicy,
 						ingressALBIPAddressType:           testIPAddressTypeDefault,
-						ingressLoadBalancerTypeAnnotation: testLoadBalancerType,
+						ingressLoadBalancerTypeAnnotation: testLoadBalancerTypeIngress,
 					},
 				},
 				Spec: ingressSpec{
@@ -89,7 +90,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 				SecurityGroup:    testSecurityGroup,
 				SSLPolicy:        testSSLPolicy,
 				IPAddressType:    testIPAddressTypeDefault,
-				LoadBalancerType: testLoadBalancerType,
+				LoadBalancerType: testLoadBalancerTypeAWS,
 			},
 			kubeIngress: &ingress{
 				Metadata: ingressItemMetadata{
@@ -102,7 +103,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 						ingressSecurityGroupAnnotation:    testSecurityGroup,
 						ingressSSLPolicyAnnotation:        testSSLPolicy,
 						ingressALBIPAddressType:           testIPAddressTypeDefault,
-						ingressLoadBalancerTypeAnnotation: testLoadBalancerType,
+						ingressLoadBalancerTypeAnnotation: testLoadBalancerTypeIngress,
 					},
 				},
 				Status: ingressStatus{
@@ -127,7 +128,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 				SecurityGroup:    testSecurityGroup,
 				SSLPolicy:        testSSLPolicy,
 				IPAddressType:    testIPAddressTypeDualStack,
-				LoadBalancerType: testLoadBalancerType,
+				LoadBalancerType: testLoadBalancerTypeAWS,
 			},
 			kubeIngress: &ingress{
 				Metadata: ingressItemMetadata{
@@ -140,7 +141,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 						ingressSecurityGroupAnnotation:    testSecurityGroup,
 						ingressSSLPolicyAnnotation:        testSSLPolicy,
 						ingressALBIPAddressType:           testIPAddressTypeDualStack,
-						ingressLoadBalancerTypeAnnotation: testLoadBalancerType,
+						ingressLoadBalancerTypeAnnotation: testLoadBalancerTypeIngress,
 					},
 				},
 				Status: ingressStatus{
@@ -155,7 +156,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 		},
 	} {
 		tt.Run(tc.msg, func(t *testing.T) {
-			a, err := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy, testLoadBalancerType)
+			a, err := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy, testLoadBalancerTypeAWS)
 			if err != nil {
 				t.Fatalf("cannot create kubernetes adapter: %v", err)
 			}
@@ -222,7 +223,7 @@ func (c *mockClient) patch(res string, payload []byte) (io.ReadCloser, error) {
 }
 
 func TestListIngress(t *testing.T) {
-	a, _ := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy, testLoadBalancerType)
+	a, _ := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy, testLoadBalancerTypeAWS)
 	client := &mockClient{}
 	a.kubeClient = client
 	ingresses, err := a.ListIngress()
@@ -240,7 +241,7 @@ func TestListIngress(t *testing.T) {
 }
 
 func TestUpdateIngressLoadBalancer(t *testing.T) {
-	a, _ := NewAdapter(testConfig, testIngressFilter, testSecurityGroup, testSSLPolicy, testLoadBalancerType)
+	a, _ := NewAdapter(testConfig, testIngressFilter, testSecurityGroup, testSSLPolicy, testLoadBalancerTypeAWS)
 	client := &mockClient{}
 	a.kubeClient = client
 	ing := &Ingress{
@@ -275,7 +276,7 @@ func TestBrokenConfig(t *testing.T) {
 		{"broken-cert", &Config{BaseURL: "dontcare", TLSClientConfig: TLSClientConfig{CAFile: "testdata/broken.pem"}}},
 	} {
 		t.Run(fmt.Sprintf("%v", test.cfg), func(t *testing.T) {
-			_, err := NewAdapter(test.cfg, testIngressFilter, testSecurityGroup, testSSLPolicy, testLoadBalancerType)
+			_, err := NewAdapter(test.cfg, testIngressFilter, testSecurityGroup, testSSLPolicy, testLoadBalancerTypeAWS)
 			if err == nil {
 				t.Error("expected an error")
 			}
@@ -284,7 +285,7 @@ func TestBrokenConfig(t *testing.T) {
 }
 
 func TestAdapter_GetConfigMap(t *testing.T) {
-	a, _ := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy, testLoadBalancerType)
+	a, _ := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy, testLoadBalancerTypeAWS)
 	client := &mockClient{}
 	a.kubeClient = client
 

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -21,6 +21,7 @@ var (
 	testSSLPolicy                   = "ELBSecurityPolicy-TLS-1-2-2017-01"
 	testIPAddressTypeDualStack      = "dualstack"
 	testIPAddressTypeDefault        = "ipv4"
+	testLoadBalancerType            = "application"
 )
 
 func TestMappingRoundtrip(tt *testing.T) {
@@ -32,28 +33,30 @@ func TestMappingRoundtrip(tt *testing.T) {
 		{
 			msg: "test parsing a simple ingress object",
 			ingress: &Ingress{
-				Namespace:      "default",
-				Name:           "foo",
-				Hostname:       "bar",
-				Scheme:         "internal",
-				CertificateARN: "zbr",
-				Shared:         true,
-				Hostnames:      []string{"domain.example.org"},
-				SecurityGroup:  testSecurityGroup,
-				SSLPolicy:      testSSLPolicy,
-				IPAddressType:  testIPAddressTypeDefault,
+				Namespace:        "default",
+				Name:             "foo",
+				Hostname:         "bar",
+				Scheme:           "internal",
+				CertificateARN:   "zbr",
+				Shared:           true,
+				Hostnames:        []string{"domain.example.org"},
+				SecurityGroup:    testSecurityGroup,
+				SSLPolicy:        testSSLPolicy,
+				IPAddressType:    testIPAddressTypeDefault,
+				LoadBalancerType: testLoadBalancerType,
 			},
 			kubeIngress: &ingress{
 				Metadata: ingressItemMetadata{
 					Namespace: "default",
 					Name:      "foo",
 					Annotations: map[string]interface{}{
-						ingressCertificateARNAnnotation: "zbr",
-						ingressSchemeAnnotation:         "internal",
-						ingressSharedAnnotation:         "true",
-						ingressSecurityGroupAnnotation:  testSecurityGroup,
-						ingressSSLPolicyAnnotation:      testSSLPolicy,
-						ingressALBIPAddressType:         testIPAddressTypeDefault,
+						ingressCertificateARNAnnotation:   "zbr",
+						ingressSchemeAnnotation:           "internal",
+						ingressSharedAnnotation:           "true",
+						ingressSecurityGroupAnnotation:    testSecurityGroup,
+						ingressSSLPolicyAnnotation:        testSSLPolicy,
+						ingressALBIPAddressType:           testIPAddressTypeDefault,
+						ingressLoadBalancerTypeAnnotation: testLoadBalancerType,
 					},
 				},
 				Spec: ingressSpec{
@@ -76,27 +79,29 @@ func TestMappingRoundtrip(tt *testing.T) {
 		{
 			msg: "test parsing an ingress object with shared=false annotation",
 			ingress: &Ingress{
-				Namespace:      "default",
-				Name:           "foo",
-				Hostname:       "bar",
-				Scheme:         "internal",
-				CertificateARN: "zbr",
-				Shared:         false,
-				SecurityGroup:  testSecurityGroup,
-				SSLPolicy:      testSSLPolicy,
-				IPAddressType:  testIPAddressTypeDefault,
+				Namespace:        "default",
+				Name:             "foo",
+				Hostname:         "bar",
+				Scheme:           "internal",
+				CertificateARN:   "zbr",
+				Shared:           false,
+				SecurityGroup:    testSecurityGroup,
+				SSLPolicy:        testSSLPolicy,
+				IPAddressType:    testIPAddressTypeDefault,
+				LoadBalancerType: testLoadBalancerType,
 			},
 			kubeIngress: &ingress{
 				Metadata: ingressItemMetadata{
 					Namespace: "default",
 					Name:      "foo",
 					Annotations: map[string]interface{}{
-						ingressCertificateARNAnnotation: "zbr",
-						ingressSchemeAnnotation:         "internal",
-						ingressSharedAnnotation:         "false",
-						ingressSecurityGroupAnnotation:  testSecurityGroup,
-						ingressSSLPolicyAnnotation:      testSSLPolicy,
-						ingressALBIPAddressType:         testIPAddressTypeDefault,
+						ingressCertificateARNAnnotation:   "zbr",
+						ingressSchemeAnnotation:           "internal",
+						ingressSharedAnnotation:           "false",
+						ingressSecurityGroupAnnotation:    testSecurityGroup,
+						ingressSSLPolicyAnnotation:        testSSLPolicy,
+						ingressALBIPAddressType:           testIPAddressTypeDefault,
+						ingressLoadBalancerTypeAnnotation: testLoadBalancerType,
 					},
 				},
 				Status: ingressStatus{
@@ -112,27 +117,29 @@ func TestMappingRoundtrip(tt *testing.T) {
 		{
 			msg: "test parsing an ingress object with dualstack annotation",
 			ingress: &Ingress{
-				Namespace:      "default",
-				Name:           "foo",
-				Hostname:       "bar",
-				Scheme:         "internal",
-				CertificateARN: "zbr",
-				Shared:         true,
-				SecurityGroup:  testSecurityGroup,
-				SSLPolicy:      testSSLPolicy,
-				IPAddressType:  testIPAddressTypeDualStack,
+				Namespace:        "default",
+				Name:             "foo",
+				Hostname:         "bar",
+				Scheme:           "internal",
+				CertificateARN:   "zbr",
+				Shared:           true,
+				SecurityGroup:    testSecurityGroup,
+				SSLPolicy:        testSSLPolicy,
+				IPAddressType:    testIPAddressTypeDualStack,
+				LoadBalancerType: testLoadBalancerType,
 			},
 			kubeIngress: &ingress{
 				Metadata: ingressItemMetadata{
 					Namespace: "default",
 					Name:      "foo",
 					Annotations: map[string]interface{}{
-						ingressCertificateARNAnnotation: "zbr",
-						ingressSchemeAnnotation:         "internal",
-						ingressSharedAnnotation:         "true",
-						ingressSecurityGroupAnnotation:  testSecurityGroup,
-						ingressSSLPolicyAnnotation:      testSSLPolicy,
-						ingressALBIPAddressType:         testIPAddressTypeDualStack,
+						ingressCertificateARNAnnotation:   "zbr",
+						ingressSchemeAnnotation:           "internal",
+						ingressSharedAnnotation:           "true",
+						ingressSecurityGroupAnnotation:    testSecurityGroup,
+						ingressSSLPolicyAnnotation:        testSSLPolicy,
+						ingressALBIPAddressType:           testIPAddressTypeDualStack,
+						ingressLoadBalancerTypeAnnotation: testLoadBalancerType,
 					},
 				},
 				Status: ingressStatus{
@@ -147,7 +154,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 		},
 	} {
 		tt.Run(tc.msg, func(t *testing.T) {
-			a, err := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy)
+			a, err := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy, testLoadBalancerType)
 			if err != nil {
 				t.Fatalf("cannot create kubernetes adapter: %v", err)
 			}
@@ -214,7 +221,7 @@ func (c *mockClient) patch(res string, payload []byte) (io.ReadCloser, error) {
 }
 
 func TestListIngress(t *testing.T) {
-	a, _ := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy)
+	a, _ := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy, testLoadBalancerType)
 	client := &mockClient{}
 	a.kubeClient = client
 	ingresses, err := a.ListIngress()
@@ -232,7 +239,7 @@ func TestListIngress(t *testing.T) {
 }
 
 func TestUpdateIngressLoadBalancer(t *testing.T) {
-	a, _ := NewAdapter(testConfig, testIngressFilter, testSecurityGroup, testSSLPolicy)
+	a, _ := NewAdapter(testConfig, testIngressFilter, testSecurityGroup, testSSLPolicy, testLoadBalancerType)
 	client := &mockClient{}
 	a.kubeClient = client
 	ing := &Ingress{
@@ -267,7 +274,7 @@ func TestBrokenConfig(t *testing.T) {
 		{"broken-cert", &Config{BaseURL: "dontcare", TLSClientConfig: TLSClientConfig{CAFile: "testdata/broken.pem"}}},
 	} {
 		t.Run(fmt.Sprintf("%v", test.cfg), func(t *testing.T) {
-			_, err := NewAdapter(test.cfg, testIngressFilter, testSecurityGroup, testSSLPolicy)
+			_, err := NewAdapter(test.cfg, testIngressFilter, testSecurityGroup, testSSLPolicy, testLoadBalancerType)
 			if err == nil {
 				t.Error("expected an error")
 			}
@@ -276,7 +283,7 @@ func TestBrokenConfig(t *testing.T) {
 }
 
 func TestAdapter_GetConfigMap(t *testing.T) {
-	a, _ := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy)
+	a, _ := NewAdapter(testConfig, testIngressFilter, testIngressDefaultSecurityGroup, testSSLPolicy, testLoadBalancerType)
 	client := &mockClient{}
 	a.kubeClient = client
 

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zalando-incubator/kube-ingress-aws-controller/aws"
 )
 
 var (
@@ -19,9 +20,9 @@ var (
 	testIngressDefaultSecurityGroup = "sg-foobar"
 	testSecurityGroup               = "sg-123456"
 	testSSLPolicy                   = "ELBSecurityPolicy-TLS-1-2-2017-01"
-	testIPAddressTypeDualStack      = "dualstack"
-	testIPAddressTypeDefault        = "ipv4"
-	testLoadBalancerType            = "application"
+	testIPAddressTypeDualStack      = aws.IPAddressTypeDualstack
+	testIPAddressTypeDefault        = aws.IPAddressTypeIPV4
+	testLoadBalancerType            = aws.LoadBalancerTypeApplication
 )
 
 func TestMappingRoundtrip(tt *testing.T) {

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -60,15 +60,16 @@ type ingressLoadBalancer struct {
 
 const (
 	// ingressALBIPAddressType is used in external-dns, https://github.com/kubernetes-incubator/external-dns/pull/1079
-	ingressALBIPAddressType         = "alb.ingress.kubernetes.io/ip-address-type"
-	ingressListResource             = "/apis/extensions/v1beta1/ingresses"
-	ingressPatchStatusResource      = "/apis/extensions/v1beta1/namespaces/%s/ingresses/%s/status"
-	ingressCertificateARNAnnotation = "zalando.org/aws-load-balancer-ssl-cert"
-	ingressSchemeAnnotation         = "zalando.org/aws-load-balancer-scheme"
-	ingressSharedAnnotation         = "zalando.org/aws-load-balancer-shared"
-	ingressSecurityGroupAnnotation  = "zalando.org/aws-load-balancer-security-group"
-	ingressSSLPolicyAnnotation      = "zalando.org/aws-load-balancer-ssl-policy"
-	ingressClassAnnotation          = "kubernetes.io/ingress.class"
+	ingressALBIPAddressType           = "alb.ingress.kubernetes.io/ip-address-type"
+	ingressListResource               = "/apis/extensions/v1beta1/ingresses"
+	ingressPatchStatusResource        = "/apis/extensions/v1beta1/namespaces/%s/ingresses/%s/status"
+	ingressCertificateARNAnnotation   = "zalando.org/aws-load-balancer-ssl-cert"
+	ingressSchemeAnnotation           = "zalando.org/aws-load-balancer-scheme"
+	ingressSharedAnnotation           = "zalando.org/aws-load-balancer-shared"
+	ingressSecurityGroupAnnotation    = "zalando.org/aws-load-balancer-security-group"
+	ingressSSLPolicyAnnotation        = "zalando.org/aws-load-balancer-ssl-policy"
+	ingressLoadBalancerTypeAnnotation = "zalando.org/aws-load-balancer-type"
+	ingressClassAnnotation            = "kubernetes.io/ingress.class"
 )
 
 func (i *ingress) getAnnotationsString(key string, defaultValue string) string {

--- a/worker.go
+++ b/worker.go
@@ -21,15 +21,16 @@ import (
 )
 
 type loadBalancer struct {
-	ingresses     map[string][]*kubernetes.Ingress
-	scheme        string
-	stack         *aws.Stack
-	shared        bool
-	securityGroup string
-	sslPolicy     string
-	ipAddressType string
-	certTTL       time.Duration
-	cwAlarms      aws.CloudWatchAlarmList
+	ingresses        map[string][]*kubernetes.Ingress
+	scheme           string
+	stack            *aws.Stack
+	shared           bool
+	securityGroup    string
+	sslPolicy        string
+	ipAddressType    string
+	certTTL          time.Duration
+	cwAlarms         aws.CloudWatchAlarmList
+	loadBalancerType string
 }
 
 const (
@@ -69,7 +70,11 @@ func (l *loadBalancer) inSync() bool {
 // adding can fail in case the load balancer reached its limit of ingress
 // certificates or if the scheme doesn't match.
 func (l *loadBalancer) AddIngress(certificateARNs []string, ingress *kubernetes.Ingress, maxCerts int) bool {
-	if l.ipAddressType != ingress.IPAddressType || l.scheme != ingress.Scheme || l.securityGroup != ingress.SecurityGroup || l.sslPolicy != ingress.SSLPolicy {
+	if l.ipAddressType != ingress.IPAddressType ||
+		l.scheme != ingress.Scheme ||
+		l.securityGroup != ingress.SecurityGroup ||
+		l.sslPolicy != ingress.SSLPolicy ||
+		l.loadBalancerType != ingress.LoadBalancerType {
 		return false
 	}
 
@@ -291,14 +296,15 @@ func getAllLoadBalancers(certTTL time.Duration, stacks []*aws.Stack) []*loadBala
 
 	for _, stack := range stacks {
 		lb := &loadBalancer{
-			stack:         stack,
-			ingresses:     make(map[string][]*kubernetes.Ingress),
-			scheme:        stack.Scheme,
-			shared:        stack.OwnerIngress == "",
-			securityGroup: stack.SecurityGroup,
-			sslPolicy:     stack.SSLPolicy,
-			ipAddressType: stack.IpAddressType,
-			certTTL:       certTTL,
+			stack:            stack,
+			ingresses:        make(map[string][]*kubernetes.Ingress),
+			scheme:           stack.Scheme,
+			shared:           stack.OwnerIngress == "",
+			securityGroup:    stack.SecurityGroup,
+			sslPolicy:        stack.SSLPolicy,
+			ipAddressType:    stack.IpAddressType,
+			loadBalancerType: stack.LoadBalancerType,
+			certTTL:          certTTL,
 		}
 		// initialize ingresses map with existing certificates from the
 		// stack.
@@ -333,6 +339,14 @@ func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs Certific
 		// limit is exeeded.
 		added := false
 		for _, lb := range loadBalancers {
+			// TODO(mlarsen): hack to phase out old load balancers
+			// which can't be updated to include type
+			// specification.
+			// Can be removed in a later version
+			if lb.loadBalancerType != "application" && lb.loadBalancerType != "network" {
+				continue
+			}
+
 			if lb.AddIngress(certificateARNs, ingress, certsPerALB) {
 				added = true
 				break
@@ -350,12 +364,13 @@ func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs Certific
 			loadBalancers = append(
 				loadBalancers,
 				&loadBalancer{
-					ingresses:     i,
-					scheme:        ingress.Scheme,
-					shared:        ingress.Shared,
-					securityGroup: ingress.SecurityGroup,
-					sslPolicy:     ingress.SSLPolicy,
-					ipAddressType: ingress.IPAddressType,
+					ingresses:        i,
+					scheme:           ingress.Scheme,
+					shared:           ingress.Shared,
+					securityGroup:    ingress.SecurityGroup,
+					sslPolicy:        ingress.SSLPolicy,
+					ipAddressType:    ingress.IPAddressType,
+					loadBalancerType: ingress.LoadBalancerType,
 				},
 			)
 		}
@@ -394,7 +409,7 @@ func createStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 
 	log.Infof("creating stack for certificates %q / ingress %q", certificates, lb.ingresses)
 
-	stackId, err := awsAdapter.CreateStack(certificates, lb.scheme, lb.securityGroup, lb.Owner(), lb.sslPolicy, lb.ipAddressType, lb.cwAlarms)
+	stackId, err := awsAdapter.CreateStack(certificates, lb.scheme, lb.securityGroup, lb.Owner(), lb.sslPolicy, lb.ipAddressType, lb.cwAlarms, lb.loadBalancerType)
 	if err != nil {
 		if isAlreadyExistsError(err) {
 			lb.stack, err = awsAdapter.GetStack(stackId)
@@ -413,7 +428,7 @@ func updateStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 
 	log.Infof("updating %q stack for %d certificates / %d ingresses", lb.scheme, len(certificates), len(lb.ingresses))
 
-	stackId, err := awsAdapter.UpdateStack(lb.stack.Name, certificates, lb.scheme, lb.sslPolicy, lb.ipAddressType, lb.cwAlarms)
+	stackId, err := awsAdapter.UpdateStack(lb.stack.Name, certificates, lb.scheme, lb.sslPolicy, lb.ipAddressType, lb.cwAlarms, lb.loadBalancerType)
 	if isNoUpdatesToBePerformedError(err) {
 		log.Debugf("stack(%q) is already up to date", certificates)
 	} else if err != nil {

--- a/worker.go
+++ b/worker.go
@@ -343,7 +343,7 @@ func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs Certific
 			// which can't be updated to include type
 			// specification.
 			// Can be removed in a later version
-			if lb.loadBalancerType != "application" && lb.loadBalancerType != "network" {
+			if lb.loadBalancerType != aws.LoadBalancerTypeApplication && lb.loadBalancerType != aws.LoadBalancerTypeNetwork {
 				continue
 			}
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -45,10 +45,10 @@ func TestAddIngress(tt *testing.T) {
 		{
 			name: "ip address type not matching",
 			loadBalancer: &loadBalancer{
-				ipAddressType: "ipv4",
+				ipAddressType: aws.IPAddressTypeIPV4,
 			},
 			ingress: &kubernetes.Ingress{
-				IPAddressType: "dualstack",
+				IPAddressType: aws.IPAddressTypeDualstack,
 			},
 			added: false,
 		},


### PR DESCRIPTION
first part to support NLB #236

resource: 
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html 

Signed-off-by: Sandor Szuecs <sandor.szuecs@zalando.de>