### PR TITLE
Drop Docker stage build to speed up build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
-# builder image
-FROM golang as builder
-
-WORKDIR /github.com/zalando-incubator/kube-ingress-aws-controller
-COPY . .
-RUN make build.linux
-
-# final image
 FROM registry.opensource.zalan.do/stups/alpine:latest
 MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
 
-COPY --from=builder /github.com/zalando-incubator/kube-ingress-aws-controller/build/linux/kube-ingress-aws-controller \
-  /bin/kube-ingress-aws-controller
+ADD build/linux/kube-ingress-aws-controller /
 
-ENTRYPOINT ["/bin/kube-ingress-aws-controller"]
+ENTRYPOINT ["/kube-ingress-aws-controller"]

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build/linux/$(BINARY): $(SOURCES)
 build/osx/$(BINARY): $(SOURCES)
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/osx/$(BINARY) -ldflags "$(LDFLAGS)" .
 
-build.docker:
+build.docker: build.linux
 	docker build --rm -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) .
 
 build.push: build.docker


### PR DESCRIPTION
Drops the docker stage build as it's much slower because you need to pull the `golang` image on the CI and re-pull all dependencies as they are not cached by CDP.

You also need to re-pull dependencies every time when running locally.