### PR TITLE
Correctly lookup asg clusterID ownership

### DIFF
--- a/aws/adapter_test.go
+++ b/aws/adapter_test.go
@@ -234,12 +234,19 @@ func TestFiltersString(tt *testing.T) {
 }
 
 func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
+	clusterID := "aws:123:eu-central-1:kube-1"
 	a := Adapter{
 		ec2Details:        map[string]*instanceDetails{},
 		autoScalingGroups: make(map[string]*autoScalingGroupDetails),
 		singleInstances:   make(map[string]*instanceDetails),
 		obsoleteInstances: make([]string, 0),
-		manifest:          &manifest{},
+		manifest: &manifest{
+			instance: &instanceDetails{
+				tags: map[string]string{
+					clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
+				},
+			},
+		},
 	}
 	for _, test := range []struct {
 		name                       string
@@ -261,8 +268,8 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			)},
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{"asg1": {
-					"foo": "bar",
-					fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+					"foo":                          "bar",
+					clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 				}}), nil),
 			},
 			2,
@@ -282,8 +289,8 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			)},
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{"asg1": {
-					"foo": "bar",
-					fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+					"foo":                          "bar",
+					clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 				}}), nil),
 			},
 			3,
@@ -305,12 +312,12 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{
 					"asg1": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg2": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					}}), nil),
 			},
 			4,
@@ -333,12 +340,12 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{
 					"asg1": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg2": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					}}), nil),
 			},
 			5,
@@ -362,16 +369,16 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{
 					"asg1": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg2": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg3": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					}}), nil),
 			},
 			6,
@@ -396,16 +403,16 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{
 					"asg1": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg2": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg3": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					}}), nil),
 			},
 			7,
@@ -431,16 +438,16 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{
 					"asg1": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg2": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg3": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					}}), nil),
 			},
 			8,
@@ -464,12 +471,12 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{
 					"asg1": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg2": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					}}), nil),
 			},
 			6,
@@ -508,12 +515,12 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{
 					"asg1": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg2": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					}}), nil),
 			},
 			7,
@@ -538,16 +545,16 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{
 					"asg1": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg2": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					},
 					"asg3": {
-						"foo": "bar",
-						fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+						"foo":                          "bar",
+						clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 					}}), nil),
 			},
 			7,
@@ -567,8 +574,8 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			)},
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{"asg1": {
-					"foo": "bar",
-					fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+					"foo":                          "bar",
+					clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 				}}), nil),
 			},
 			3,
@@ -587,8 +594,8 @@ func TestUpdateAutoScalingGroupsAndInstances(tt *testing.T) {
 			)},
 			autoscalingMockOutputs{
 				describeAutoScalingGroups: R(mockDASGOutput(map[string]asgtags{"asg1": {
-					"foo": "bar",
-					fmt.Sprintf("%s/aws:123:eu-central-1:kube-1", clusterIDTagPrefix): resourceLifecycleOwned,
+					"foo":                          "bar",
+					clusterIDTagPrefix + clusterID: resourceLifecycleOwned,
 				}}), nil),
 			},
 			2,

--- a/aws/asg.go
+++ b/aws/asg.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"strings"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
@@ -87,8 +85,10 @@ func getAutoScalingGroupsByName(service autoscalingiface.AutoScalingAPI, autoSca
 	return result, nil
 }
 
-func getOwnedAutoScalingGroups(service autoscalingiface.AutoScalingAPI) (map[string]*autoScalingGroupDetails, error) {
+func getOwnedAutoScalingGroups(service autoscalingiface.AutoScalingAPI, clusterID string) (map[string]*autoScalingGroupDetails, error) {
 	params := &autoscaling.DescribeAutoScalingGroupsInput{}
+
+	clusterIDTag := clusterIDTagPrefix + clusterID
 
 	result := make(map[string]*autoScalingGroupDetails)
 	err := service.DescribeAutoScalingGroupsPages(params,
@@ -103,7 +103,7 @@ func getOwnedAutoScalingGroups(service autoscalingiface.AutoScalingAPI) (map[str
 					value := aws.StringValue(td.Value)
 					tags[key] = value
 
-					if strings.HasPrefix(key, clusterIDTagPrefix) && value == resourceLifecycleOwned {
+					if key == clusterIDTag && value == resourceLifecycleOwned {
 						isOwned = true
 					}
 				}

--- a/worker.go
+++ b/worker.go
@@ -408,7 +408,8 @@ func isNoUpdatesToBePerformedError(err error) bool {
 }
 
 func updateIngress(kubeAdapter *kubernetes.Adapter, lb *loadBalancer) {
-	if lb.stack == nil {
+	// only update ingress if the stack exists and is in a complete state.
+	if lb.stack == nil || !lb.stack.IsComplete() {
 		return
 	}
 	dnsName := strings.ToLower(lb.stack.DNSName) // lower case to satisfy Kubernetes reqs


### PR DESCRIPTION
Fixes a bug introduced in #245 (https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/248) where only the clusterID prefix was checked, resulting in the controller collecting *ALL* ASGs in the account including those not part of the cluster.

Additionally it checks that the stack is ready before trying to update ingress or target groups. Before this would lead to errors until the stack was fully created in AWS.