### PR TITLE
Don't add others ingresses to already owned/non-shared stack

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -78,6 +78,10 @@ func (l *loadBalancer) AddIngress(certificateARNs []string, ingress *kubernetes.
 		owner = l.stack.OwnerIngress
 	}
 
+	if owner != "" && resourceName != owner {
+		return false
+	}
+
 	if !ingress.Shared && resourceName != owner {
 		return false
 	}

--- a/worker_test.go
+++ b/worker_test.go
@@ -65,6 +65,20 @@ func TestAddIngress(tt *testing.T) {
 			added: false,
 		},
 		{
+			name: "don't add ingresses shared, to an owned load balancer",
+			loadBalancer: &loadBalancer{
+				stack: &aws.Stack{
+					OwnerIngress: "foo/bar",
+				},
+			},
+			ingress: &kubernetes.Ingress{
+				Shared:    true,
+				Namespace: "foo",
+				Name:      "baz",
+			},
+			added: false,
+		},
+		{
 			name: "add ingress to empty load balancer",
 			loadBalancer: &loadBalancer{
 				stack: &aws.Stack{},


### PR DESCRIPTION
It seems like we have a bug where shared ingresses can be added to an already non-shared stack owned by another ingress.

Need to add tests to validate that this is indeed a bug.