### PR TITLE
Updating go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   - go: tip
 
 env:
-  GOLANGCI_RELEASE="v1.18.0"
+  GOLANGCI_RELEASE="v1.19.1"
 
 before_install:
 - GO111MODULE=off go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 language: go
 
 go:
-- "1.12.x"
+- "1.13.x"
 - tip
 
 matrix:
@@ -14,10 +14,10 @@ matrix:
   - go: tip
 
 env:
-  GO111MODULE=on GOLANGCI_RELEASE="v1.16.0"
+  GOLANGCI_RELEASE="v1.18.0"
 
 before_install:
-- go get github.com/mattn/goveralls
+- GO111MODULE=off go get github.com/mattn/goveralls
 - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_RELEASE}
 
 script:

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,7 @@
 module github.com/zalando-incubator/kube-ingress-aws-controller
 
-go 1.12
-
 require (
-	github.com/aws/aws-sdk-go v1.23.17
+	github.com/aws/aws-sdk-go v1.24.6
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-playground/locales v0.12.1 // indirect
@@ -26,5 +24,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.19.0 // indirect
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.23.17 h1:IGNAvtR7ckMEHhy+ObG9xw6DFqEE4Ual0LYXsVTZSLQ=
-github.com/aws/aws-sdk-go v1.23.17/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.24.6 h1:QmBKT5yfcWuMz6+n53YFl6uiaTCSjhcEk1I5jIRU+uU=
+github.com/aws/aws-sdk-go v1.24.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
Update go to 1.13
Updating aws-sdk-go
Updating golangci-lint