### PR TITLE
Restore CUSTOM_FILTERS function which was broken in 0.8.4.

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -655,17 +655,21 @@ func (a *Adapter) UpdateAutoScalingGroupsAndInstances() error {
 	}
 	a.singleInstances = newSingleInstances
 
+	// Get the names of the ASGs seen from the filtered instances as we check for singles
+	asgNameMap := make(map[string]bool)
 	for instanceID, details := range a.ec2Details {
-		_, err := getAutoScalingGroupName(details.tags)
+		name, err := getAutoScalingGroupName(details.tags)
 		if err != nil {
 			// Instance is not in ASG, save in single instances list.
 			a.singleInstances[instanceID] = details
 			continue
+		} else {
+			asgNameMap[name] = true
 		}
 	}
 
 	newAutoScalingGroups := make(map[string]*autoScalingGroupDetails)
-	fetchedAutoScalingGroups, err := getOwnedAutoScalingGroups(a.autoscaling, a.ClusterID())
+	fetchedAutoScalingGroups, err := getOwnedAutoScalingGroups(a.autoscaling, a.ClusterID(), asgNameMap)
 	if err != nil {
 		return err
 	}

--- a/aws/asg.go
+++ b/aws/asg.go
@@ -85,7 +85,7 @@ func getAutoScalingGroupsByName(service autoscalingiface.AutoScalingAPI, autoSca
 	return result, nil
 }
 
-func getOwnedAutoScalingGroups(service autoscalingiface.AutoScalingAPI, clusterID string) (map[string]*autoScalingGroupDetails, error) {
+func getOwnedAutoScalingGroups(service autoscalingiface.AutoScalingAPI, clusterID string, asgNameMap map[string]bool) (map[string]*autoScalingGroupDetails, error) {
 	params := &autoscaling.DescribeAutoScalingGroupsInput{}
 
 	clusterIDTag := clusterIDTagPrefix + clusterID
@@ -103,7 +103,7 @@ func getOwnedAutoScalingGroups(service autoscalingiface.AutoScalingAPI, clusterI
 					value := aws.StringValue(td.Value)
 					tags[key] = value
 
-					if key == clusterIDTag && value == resourceLifecycleOwned {
+					if key == clusterIDTag && value == resourceLifecycleOwned && asgNameMap[name] {
 						isOwned = true
 					}
 				}


### PR DESCRIPTION
This fixes #266, which describes the issue being addressed here. In short, CUSTOM_FILTERS is only applied to DescribeInstances, so ensure we limit the ASGs considered to those seen in the described instances.

It was originally considered to try to apply tag filtering to the ASG lookups as well, but in the end, simply restored the prior logic with a minimal patch.

Signed-off-by: Joe Hohertz <joe@viafoura.com>