### PR TITLE
implement an http-to-https redirect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,10 @@ listening on that port.
 If you want to change the default ports, you can control it using the
 `-target-port` and `-health-check-port` flags.
 
+## HTTP to HTTPS Redirection
+
+By default, the controller will expose both HTTP and HTTPS ports on the load balancer, and forward both listeners to the target port. Setting the flag `-redirect-http-to-https` will instead configure the HTTP listener to emit a 301 redirect for any request received, with the destination location being the same URL but with the HTTPS scheme vs. HTTP. The specifics are described in the [relevant aws documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-redirectconfig.html).
+
 ### Backward Compatibility
 
 The controller used to have only the `-health-check-port` flag available, and would use the same port as health check and the target port.

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -293,7 +293,7 @@ func (a *Adapter) WithWafWebAclId(wafWebAclId string) *Adapter {
 }
 
 // WithHttpRedirectToHttps returns the receiver adapter after changing the flag to effect HTTP->HTTPS redirection
-func (a *Adapter) WithHttpRedirectToHttps (httpRedirectToHttps bool) *Adapter {
+func (a *Adapter) WithHttpRedirectToHttps(httpRedirectToHttps bool) *Adapter {
 	a.httpRedirectToHttps = httpRedirectToHttps
 	return a
 }

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -59,6 +59,7 @@ type Adapter struct {
 	albLogsS3Bucket            string
 	albLogsS3Prefix            string
 	wafWebAclId                string
+	httpRedirectToHttps        bool
 }
 
 type manifest struct {
@@ -291,6 +292,12 @@ func (a *Adapter) WithWafWebAclId(wafWebAclId string) *Adapter {
 	return a
 }
 
+// WithHttpRedirectToHttps returns the receiver adapter after changing the flag to effect HTTP->HTTPS redirection
+func (a *Adapter) WithHttpRedirectToHttps (httpRedirectToHttps bool) *Adapter {
+	a.httpRedirectToHttps = httpRedirectToHttps
+	return a
+}
+
 // ClusterID returns the ClusterID tag that all resources from the same Kubernetes cluster share.
 // It's taken from the current ec2 instance.
 func (a *Adapter) ClusterID() string {
@@ -470,6 +477,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 		albLogsS3Prefix:              a.albLogsS3Prefix,
 		wafWebAclId:                  a.wafWebAclId,
 		cwAlarms:                     cwAlarms,
+		httpRedirectToHttps:          a.httpRedirectToHttps,
 	}
 
 	return createStack(a.cloudformation, spec)
@@ -504,6 +512,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 		albLogsS3Prefix:              a.albLogsS3Prefix,
 		wafWebAclId:                  a.wafWebAclId,
 		cwAlarms:                     cwAlarms,
+		httpRedirectToHttps:          a.httpRedirectToHttps,
 	}
 
 	return updateStack(a.cloudformation, spec)

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -134,6 +134,7 @@ type stackSpec struct {
 	albLogsS3Prefix              string
 	wafWebAclId                  string
 	cwAlarms                     CloudWatchAlarmList
+	httpRedirectToHttps          bool
 }
 
 type healthCheck struct {

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -78,7 +78,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 		template.AddResource("HTTPListener", &cloudformation.ElasticLoadBalancingV2Listener{
 			DefaultActions: &cloudformation.ElasticLoadBalancingV2ListenerActionList{
 				{
-					Type:           cloudformation.String("redirect"),
+					Type: cloudformation.String("redirect"),
 					RedirectConfig: &cloudformation.ElasticLoadBalancingV2ListenerRedirectConfig{
 						Protocol:   cloudformation.String("HTTPS"),
 						Port:       cloudformation.String("443"),

--- a/controller.go
+++ b/controller.go
@@ -24,8 +24,9 @@ import (
 )
 
 const (
-	defaultDisableSNISupport = false
-	defaultCertTTL           = 30 * time.Minute
+	defaultDisableSNISupport   = false
+	defaultHttpRedirectToHttps = false
+	defaultCertTTL             = 30 * time.Minute
 )
 
 var (
@@ -57,6 +58,7 @@ var (
 	albLogsS3Bucket            string
 	albLogsS3Prefix            string
 	wafWebAclId                string
+	httpRedirectToHttps        bool
 	debugFlag                  bool
 	quietFlag                  bool
 	firstRun                   bool = true
@@ -108,6 +110,7 @@ func loadSettings() error {
 	flag.StringVar(&albLogsS3Prefix, "logs-s3-prefix", aws.DefaultAlbS3LogsPrefix, "Prefix within S3 bucket to be used for ALB logging")
 	flag.StringVar(&wafWebAclId, "aws-waf-web-acl-id", aws.DefaultWafWebAclId, "Waf web acl id to be associated with the ALB")
 	flag.StringVar(&cwAlarmConfigMap, "cloudwatch-alarms-config-map", "", "ConfigMap location of the form 'namespace/config-map-name' where to read CloudWatch Alarm configuration from. Ignored if empty.")
+	flag.BoolVar(&httpRedirectToHttps, "redirect-http-to-https", defaultHttpRedirectToHttps, "Configure HTTP listener to redirect to HTTPS")
 
 	flag.Parse()
 
@@ -239,7 +242,8 @@ func main() {
 		WithIpAddressType(ipAddressType).
 		WithAlbLogsS3Bucket(albLogsS3Bucket).
 		WithAlbLogsS3Prefix(albLogsS3Prefix).
-		WithWafWebAclId(wafWebAclId)
+		WithWafWebAclId(wafWebAclId).
+		WithHttpRedirectToHttps(httpRedirectToHttps)
 
 	certificatesProvider, err := certs.NewCachingProvider(
 		certPollingInterval,

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,10 @@ require (
 	github.com/golang/protobuf v0.0.0-20171113180720-1e59b77b52bf // indirect
 	github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/linki/instrumented_http v0.2.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/mweagle/go-cloudformation v0.0.0-20180525044411-e40a034597a3
+	github.com/mweagle/go-cloudformation v0.0.0-20190927125801-911e86284f4e
 	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v0.8.0
 	github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612 // indirect
@@ -23,7 +24,7 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
-	gopkg.in/go-playground/validator.v9 v9.19.0 // indirect
+	gopkg.in/go-playground/validator.v9 v9.30.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -23,12 +23,16 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/leodido/go-urn v1.1.0 h1:Sm1gr51B1kKyfD2BlRcLSiEkffoG96g6TPv6eRoEiB8=
+github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/linki/instrumented_http v0.2.0 h1:zLhcB3Q/McQQqml3qd5kzdZ0cGnL3vquPFIW2338f5Y=
 github.com/linki/instrumented_http v0.2.0/go.mod h1:pjYbItoegfuVi2GUOMhEqzvm/SJKuEL3H0tc8QRLRFk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mweagle/go-cloudformation v0.0.0-20180525044411-e40a034597a3 h1:+EUzCls6hotoQKC1J6ofmC1WQWRjzLNHG5UaJ5v0fbA=
 github.com/mweagle/go-cloudformation v0.0.0-20180525044411-e40a034597a3/go.mod h1:ZkuUgvDIuRW0sYTRfCz7VmL3IodhIufcb8HNdI6b6AI=
+github.com/mweagle/go-cloudformation v0.0.0-20190927125801-911e86284f4e h1:vCfcv5vk51DFFxdhCYS8w5SBhwaYaLDlcd81jEAdJQM=
+github.com/mweagle/go-cloudformation v0.0.0-20190927125801-911e86284f4e/go.mod h1:ZkuUgvDIuRW0sYTRfCz7VmL3IodhIufcb8HNdI6b6AI=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -63,5 +67,7 @@ gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXa
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.19.0 h1:PTE3gBwP61sZfxOsROkUZbXONv+7N5Mw1Et6S+4NGBA=
 gopkg.in/go-playground/validator.v9 v9.19.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/go-playground/validator.v9 v9.30.0 h1:Wk0Z37oBmKj9/n+tPyBHZmeL19LaCoK3Qq48VwYENss=
+gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Implements the feature described in #199

Simply adds a controller flag, that if set, replaces the forward rule on the HTTPListener with a redirection rule to HTTPS, preserving the rest of the URL.

Note for reviewer: This did require me to update go-cloudformation (and it's dependencies), as `cloudformation.ElasticLoadBalancingV2ListenerRedirectConfig` was not present in the pinned version.
