### PR TITLE
Better handling of invalid SSL Policy

### DIFF
--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/zalando-incubator/kube-ingress-aws-controller/aws"
 )
 
 type Adapter struct {
@@ -120,6 +121,11 @@ func (a *Adapter) newIngressFromKube(kubeIngress *ingress) *Ingress {
 		ipAddressType = ipAddressTypeDualstack
 	}
 
+	sslPolicy := kubeIngress.getAnnotationsString(ingressSSLPolicyAnnotation, a.ingressDefaultSSLPolicy)
+	if _, ok := aws.SSLPolicies[sslPolicy]; !ok {
+		sslPolicy = a.ingressDefaultSSLPolicy
+	}
+
 	return &Ingress{
 		CertificateARN: kubeIngress.getAnnotationsString(ingressCertificateARNAnnotation, ""),
 		Namespace:      kubeIngress.Metadata.Namespace,
@@ -129,7 +135,7 @@ func (a *Adapter) newIngressFromKube(kubeIngress *ingress) *Ingress {
 		Hostnames:      hostnames,
 		Shared:         shared,
 		SecurityGroup:  kubeIngress.getAnnotationsString(ingressSecurityGroupAnnotation, a.ingressDefaultSecurityGroup),
-		SSLPolicy:      kubeIngress.getAnnotationsString(ingressSSLPolicyAnnotation, a.ingressDefaultSSLPolicy),
+		SSLPolicy:      sslPolicy,
 		IPAddressType:  ipAddressType,
 	}
 }


### PR DESCRIPTION
This improves the handling of SSL policy in case the user specifies an invalid value in the annotation.

Before we would just check for valid SSL Policy on Stack creation and fall back to the default policy in case it wasn't valid. This had the problem that new stacks would be created again and again in case the policy was invalid because each newly created stack wouldn't satisfy the ingress with a different (invalid) SSL Policy defined.

Now we fall back to the default already when reading the ingress. Additionally we add a safer validation to the stack creation part where it will fail if the SSL Policy is invalid.

This is missing some form of error reporting for the users, but I think this should be handled in a separate PR e.g. by adding events.