### PR TITLE
Switch to kingpin as flag lib for simpler validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ This information is used to manage AWS resources for each ingress objects of the
 
 ## Upgrade
 
+### <0.9.0 to >=v0.9.0
+
+Version `v0.9.0` changes the internal flag parsing library to
+[kingpin][kingpin] this means flags are now defined with `--` (two dashes)
+instead of a single dash. You need to change all the flags like this:
+`-stack-termination-protection` -> `--stack-termination-protection` before
+running `v0.9.0` of the controller.
+
+[kingpin]: https://github.com/alecthomas/kingpin
+
 ### <v0.8.0 to >=v0.8.0
 
 Version `v0.8.0` added certificate verification check to automatically ignore
@@ -104,7 +114,7 @@ SecurityGroup auto detection needs the following AWS Tags on the
 SecurityGroup:
 - `kubernetes.io/cluster/<cluster-id>=owned`
 - `kubernetes:application=<controller-id>`, controller-id defaults to
-`kube-ingress-aws-controller` and can be set by flag `-controller-id=<my-ctrl-id>`.
+`kube-ingress-aws-controller` and can be set by flag `--controller-id=<my-ctrl-id>`.
 
 AutoScalingGroup auto detection needs the same AWS tags  on the
 AutoScalingGroup as defined for the SecurityGroup.
@@ -225,7 +235,7 @@ latter will use the automatically selected certificates.
 
 By default the ingress-controller will aggregate all ingresses under as few
 Application Load Balancers as possible (unless running with
-`-disable-sni-support`). If you like to provision an Application Load Balancer
+`--disable-sni-support`). If you like to provision an Application Load Balancer
 that is unique for an ingress you can use the annotation
 `zalando.org/aws-load-balancer-shared: "false"`.
 
@@ -286,7 +296,7 @@ You can only select from `internet-facing` (default) and `internal` options.
 
 You can select the default
 [SSLPolicy](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies),
-with the flag `-ssl-policy=ELBSecurityPolicy-TLS-1-2-2017-01`. This
+with the flag `--ssl-policy=ELBSecurityPolicy-TLS-1-2-2017-01`. This
 choice can be overriden by the Kubernetes Ingress annotation
 `zalando.org/aws-load-balancer-ssl-policy` to any valid value. Valid
 values will be checked by the controller.
@@ -386,7 +396,7 @@ In some cases it might be useful to run multiple instances of this controller:
 * Using a different set of traffic processing nodes
 * Using different frontend routers (e.g.: Skipper and Traefik)
 
-You can use the flag `-controller-id` to set a token that will be used to isolate resources between controller instances.
+You can use the flag `--controller-id` to set a token that will be used to isolate resources between controller instances.
 This value will be used to tag those resources.
 
 If you don't pass an ID, the default `kube-ingress-aws-controller` will be used.
@@ -408,8 +418,8 @@ By default, the controller will expose both HTTP and HTTPS ports on the load bal
 
 ### Backward Compatibility
 
-The controller used to have only the `-health-check-port` flag available, and would use the same port as health check and the target port.
-Those ports are now configured individually. If you relied on this behavior, please include the `-target-port` in your configuration.
+The controller used to have only the `--health-check-port` flag available, and would use the same port as health check and the target port.
+Those ports are now configured individually. If you relied on this behavior, please include the `--target-port` in your configuration.
 
 ## Trying it out
 

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -37,7 +37,6 @@ type Adapter struct {
 	iam            iamiface.IAMAPI
 	cloudformation cloudformationiface.CloudFormationAPI
 
-	customTemplate             string
 	manifest                   *manifest
 	healthCheckPath            string
 	healthCheckPort            uint
@@ -57,7 +56,7 @@ type Adapter struct {
 	albLogsS3Bucket            string
 	albLogsS3Prefix            string
 	wafWebAclId                string
-	httpRedirectToHttps        bool
+	httpRedirectToHTTPS        bool
 	nlbCrossZone               bool
 	customFilter               string
 }
@@ -135,6 +134,15 @@ var (
 		"ELBSecurityPolicy-TLS-1-1-2017-01":     true,
 		"ELBSecurityPolicy-2015-05":             true,
 		"ELBSecurityPolicy-TLS-1-0-2015-04":     true,
+	}
+	SSLPoliciesList = []string{
+		"ELBSecurityPolicy-2016-08",
+		"ELBSecurityPolicy-FS-2018-06",
+		"ELBSecurityPolicy-TLS-1-2-2017-01",
+		"ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
+		"ELBSecurityPolicy-TLS-1-1-2017-01",
+		"ELBSecurityPolicy-2015-05",
+		"ELBSecurityPolicy-TLS-1-0-2015-04",
 	}
 )
 
@@ -247,13 +255,6 @@ func (a *Adapter) WithIdleConnectionTimeout(interval time.Duration) *Adapter {
 	return a
 }
 
-// WithCustomTemplate returns the receiver adapter after changing the CloudFormation template that should be used
-// to create Load Balancer stacks
-func (a *Adapter) WithCustomTemplate(template string) *Adapter {
-	a.customTemplate = template
-	return a
-}
-
 // WithControllerID returns the receiver adapter after changing the CloudFormation template that should be used
 // to create Load Balancer stacks
 func (a *Adapter) WithControllerID(id string) *Adapter {
@@ -301,9 +302,9 @@ func (a *Adapter) WithWafWebAclId(wafWebAclId string) *Adapter {
 	return a
 }
 
-// WithHttpRedirectToHttps returns the receiver adapter after changing the flag to effect HTTP->HTTPS redirection
-func (a *Adapter) WithHttpRedirectToHttps(httpRedirectToHttps bool) *Adapter {
-	a.httpRedirectToHttps = httpRedirectToHttps
+// WithHTTPRedirectToHTTPS returns the receiver adapter after changing the flag to effect HTTP->HTTPS redirection
+func (a *Adapter) WithHTTPRedirectToHTTPS(httpRedirectToHTTPS bool) *Adapter {
+	a.httpRedirectToHTTPS = httpRedirectToHTTPS
 	return a
 }
 
@@ -508,7 +509,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 		albLogsS3Prefix:              a.albLogsS3Prefix,
 		wafWebAclId:                  a.wafWebAclId,
 		cwAlarms:                     cwAlarms,
-		httpRedirectToHttps:          a.httpRedirectToHttps,
+		httpRedirectToHTTPS:          a.httpRedirectToHTTPS,
 		nlbCrossZone:                 a.nlbCrossZone,
 	}
 
@@ -545,7 +546,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 		albLogsS3Prefix:              a.albLogsS3Prefix,
 		wafWebAclId:                  a.wafWebAclId,
 		cwAlarms:                     cwAlarms,
-		httpRedirectToHttps:          a.httpRedirectToHttps,
+		httpRedirectToHTTPS:          a.httpRedirectToHTTPS,
 	}
 
 	return updateStack(a.cloudformation, spec)

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -137,7 +137,7 @@ type stackSpec struct {
 	albLogsS3Prefix              string
 	wafWebAclId                  string
 	cwAlarms                     CloudWatchAlarmList
-	httpRedirectToHttps          bool
+	httpRedirectToHTTPS          bool
 	nlbCrossZone                 bool
 }
 

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -86,7 +86,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 		tlsProtocol = "TLS"
 	}
 
-	if spec.loadbalancerType == LoadBalancerTypeApplication && spec.httpRedirectToHttps {
+	if spec.loadbalancerType == LoadBalancerTypeApplication && spec.httpRedirectToHTTPS {
 		template.AddResource("HTTPListener", &cloudformation.ElasticLoadBalancingV2Listener{
 			DefaultActions: &cloudformation.ElasticLoadBalancingV2ListenerActionList{
 				{

--- a/aws/cf_template_test.go
+++ b/aws/cf_template_test.go
@@ -100,7 +100,7 @@ func TestGenerateTemplate(t *testing.T) {
 			name: "http -> https redirect should be enabled for Application load balancers",
 			spec: &stackSpec{
 				loadbalancerType:    LoadBalancerTypeApplication,
-				httpRedirectToHttps: true,
+				httpRedirectToHTTPS: true,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
 				require.NotNil(t, template.Resources["HTTPListener"])
@@ -116,7 +116,7 @@ func TestGenerateTemplate(t *testing.T) {
 			name: "http -> https redirect should NOT be enabled for Network load balancers",
 			spec: &stackSpec{
 				loadbalancerType:    LoadBalancerTypeNetwork,
-				httpRedirectToHttps: true,
+				httpRedirectToHTTPS: true,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
 				require.NotNil(t, template.Resources["HTTPListener"])

--- a/deploy/ingress-controller.yaml.example
+++ b/deploy/ingress-controller.yaml.example
@@ -29,4 +29,4 @@ spec:
         - name: AWS_REGION
           value: <REGIOn>
         args:
-          - "-ip-addr-type=dualstack" OR "-ip-addr-type=ipv4" OR OMIT TO HAVE ipv4
+          - "--ip-addr-type=dualstack" OR "--ip-addr-type=ipv4" OR OMIT TO HAVE ipv4

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/prometheus/client_golang v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/aws/aws-sdk-go v1.25.8 h1:n7I+HUUXjun2CsX7JK+1hpRIkZrlKhd3nayeb+Xmavs=
 github.com/aws/aws-sdk-go v1.25.8/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -91,6 +93,7 @@ golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 h1:4y9KwBHBgBNwDbtu44R5o1fdO
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Switch to kingpin as flag lib for simpler validation

Fix: #283

Also changed from variable names and removed unused flag `cf-custom-template`.