### PR TITLE
Help usage for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BUILD_FLAGS   ?= -v
 LDFLAGS       ?= -X main.version=$(VERSION) -X main.buildstamp=$(shell date -u '+%Y-%m-%d_%I:%M:%S%p') -X main.githash=$(shell git rev-parse HEAD) -w -s
 
 
-default: help
+default: build.local
 
 ## clean: cleans the binary
 clean:


### PR DESCRIPTION
By default make is not showing any possible options what one can run, this is a simple trick which uses comments by using and replaces it by using sed.
```console
$ make help
Usage:

  clean          cleans the binary
  test           runs go test
  lint           runs golangci-lint
  fmt            formats all go files
  build.local    builds a local binary in build directory
  build.local    builds a binary for linux/amd64 in build directory
  build.osx      builds a binary for osx/amd64 in build directory
  build.docker   builds docker image
  build.push     pushes docker image to registry
  recreate.ca    recreates a signed local test certificate
  help           prints this help message
```