### PR TITLE
feature: support cluster.local 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This information is used to manage AWS resources for each ingress objects of the
 - Automatic cleanup of unnecessary managed resources
 - Support for both [Application Load Balancers][alb] and [Network Load Balancers][nlb].
 - Support for internet-facing and internal load balancers
+- Support for ignoring internal ingress, that only have `cluster.local` domains
 - Support for multiple Auto Scaling Groups
 - Support for instances that are not part of Auto Scaling Group
 - Support for SSLPolicy, set default and per ingress
@@ -190,7 +191,7 @@ During startup phase EC2 filters are constructed as follows:
   filters are `tag:kubernetes.io/cluster/<cluster-id>=owned tag-key=k8s.io/role/node` where `<cluster-id>`
   is determined from EC2 tags of instance on which Ingress Controller pod is started.
 
-`CUSTOM_FILTERS` is a list of filters separated by spaces. Each filter has a form of `name=value` where name can be a `tag:` or `tag-key:` prefixed expression, as would be recognized by the EC2 API, and value is value of a filter, or a comma seperated list of values. 
+`CUSTOM_FILTERS` is a list of filters separated by spaces. Each filter has a form of `name=value` where name can be a `tag:` or `tag-key:` prefixed expression, as would be recognized by the EC2 API, and value is value of a filter, or a comma seperated list of values.
 
 For example:
 
@@ -320,6 +321,30 @@ spec:
 ```
 
 You can only select from `internet-facing` (default) and `internal` options.
+
+#### Omit to create a Load Balancer for cluster internal domains
+
+Since `>=v0.10.5`, you can create Ingress objects with `host` rules,
+that have the `.cluster.local` and the controller will not create an
+ALB for this.
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: myingress
+spec:
+  rules:
+  - host: test-app.skipper.cluster.local
+    http:
+      paths:
+      - backend:
+          serviceName: test-app-service
+          servicePort: main-port
+```
+
+If you pass `--cluster-local-domain=".cluster.local"`, you can change
+what domain is considered cluster internal.
 
 #### Create Load Balancer with SSL Policy
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This information is used to manage AWS resources for each ingress objects of the
 - Automatic cleanup of unnecessary managed resources
 - Support for both [Application Load Balancers][alb] and [Network Load Balancers][nlb].
 - Support for internet-facing and internal load balancers
-- Support for ignoring internal ingress, that only have `cluster.local` domains
+- Support for ignoring cluster-internal ingress, that only have `--cluster-local-domain=cluster.local` domains.
 - Support for multiple Auto Scaling Groups
 - Support for instances that are not part of Auto Scaling Group
 - Support for SSLPolicy, set default and per ingress

--- a/controller.go
+++ b/controller.go
@@ -101,8 +101,8 @@ func loadSettings() error {
 		StringVar(&ingressClassFilters)
 	kingpin.Flag("controller-id", "controller ID used to differentiate resources from multiple aws ingress controller instances").
 		Default(aws.DefaultControllerID).StringVar(&controllerID)
-	kingpin.Flag("cluster-local-domain", "Cluster local domain is used to detect hostnames, that won't trigger a creation of an AWS load balancer").
-		Default(kubernetes.DefaultClusterLocalDomain).StringVar(&clusterLocalDomain)
+	kingpin.Flag("cluster-local-domain", "Cluster local domain is used to detect hostnames, that won't trigger a creation of an AWS load balancer, empty string will not change the default behavior. In Kubernetes you might want to pass cluster.local").
+		Default("").StringVar(&clusterLocalDomain)
 	kingpin.Flag("max-certs-alb", fmt.Sprintf("sets the maximum number of certificates to be attached to an ALB. Cannot be higher than %d", aws.DefaultMaxCertsPerALB)).
 		Default(strconv.Itoa(aws.DefaultMaxCertsPerALB)).IntVar(&maxCertsPerALB) // TODO: max
 	kingpin.Flag("ssl-policy", "Security policy that will define the protocols/ciphers accepts by the SSL listener").

--- a/controller.go
+++ b/controller.go
@@ -48,6 +48,7 @@ var (
 	idleConnectionTimeout      time.Duration
 	ingressClassFilters        string
 	controllerID               string
+	clusterLocalDomain         string
 	maxCertsPerALB             int
 	sslPolicy                  string
 	blacklistCertARNs          []string
@@ -100,6 +101,8 @@ func loadSettings() error {
 		StringVar(&ingressClassFilters)
 	kingpin.Flag("controller-id", "controller ID used to differentiate resources from multiple aws ingress controller instances").
 		Default(aws.DefaultControllerID).StringVar(&controllerID)
+	kingpin.Flag("cluster-local-domain", "Cluster local domain is used to detect hostnames, that won't trigger a creation of an AWS load balancer").
+		Default(kubernetes.DefaultClusterLocalDomain).StringVar(&clusterLocalDomain)
 	kingpin.Flag("max-certs-alb", fmt.Sprintf("sets the maximum number of certificates to be attached to an ALB. Cannot be higher than %d", aws.DefaultMaxCertsPerALB)).
 		Default(strconv.Itoa(aws.DefaultMaxCertsPerALB)).IntVar(&maxCertsPerALB) // TODO: max
 	kingpin.Flag("ssl-policy", "Security policy that will define the protocols/ciphers accepts by the SSL listener").
@@ -258,7 +261,7 @@ func main() {
 		ingressClassFiltersList = strings.Split(ingressClassFilters, ",")
 	}
 
-	kubeAdapter, err = kubernetes.NewAdapter(kubeConfig, ingressClassFiltersList, awsAdapter.SecurityGroupID(), sslPolicy, loadBalancerType)
+	kubeAdapter, err = kubernetes.NewAdapter(kubeConfig, ingressClassFiltersList, awsAdapter.SecurityGroupID(), sslPolicy, loadBalancerType, clusterLocalDomain)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -142,7 +142,7 @@ func (a *Adapter) newIngressFromKube(kubeIngress *ingress) *Ingress {
 	}
 
 	for _, rule := range kubeIngress.Spec.Rules {
-		if rule.Host != "" && !strings.HasSuffix(rule.Host, a.clusterLocalDomain) {
+		if rule.Host != "" && (a.clusterLocalDomain == "" || !strings.HasSuffix(rule.Host, a.clusterLocalDomain)) {
 			hostnames = append(hostnames, rule.Host)
 		}
 	}
@@ -170,7 +170,7 @@ func (a *Adapter) newIngressFromRouteGroup(rg *routegroup) *Ingress {
 	}
 
 	for _, host := range rg.Spec.Hosts {
-		if host != "" && !strings.HasSuffix(host, a.clusterLocalDomain) {
+		if host != "" && (a.clusterLocalDomain == "" || !strings.HasSuffix(host, a.clusterLocalDomain)) {
 			hostnames = append(hostnames, host)
 		}
 	}

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -342,19 +342,13 @@ func (a *Adapter) ListIngress() ([]*Ingress, error) {
 			ingressClass := getAnnotationsString(ingress.Metadata.Annotations, ingressClassAnnotation, "")
 			for _, v := range a.ingressFilters {
 				if v == ingressClass {
-					ing := a.newIngressFromKube(ingress)
-					if ing != nil {
-						ret = append(ret, ing)
-					}
+					ret = append(ret, a.newIngressFromKube(ingress))
 				}
 			}
 		}
 	} else {
 		for _, ingress := range il.Items {
-			ing := a.newIngressFromKube(ingress)
-			if ing != nil {
-				ret = append(ret, ing)
-			}
+			ret = append(ret, a.newIngressFromKube(ingress))
 		}
 	}
 	return ret, nil
@@ -376,20 +370,13 @@ func (a *Adapter) ListRoutegroups() ([]*Ingress, error) {
 			ingressClass := getAnnotationsString(rg.Metadata.Annotations, ingressClassAnnotation, "")
 			for _, v := range a.ingressFilters {
 				if v == ingressClass {
-					ing := a.newIngressFromRouteGroup(rg)
-					if ing != nil {
-						ret = append(ret, ing)
-					}
+					ret = append(ret, a.newIngressFromRouteGroup(rg))
 				}
 			}
 		}
 	} else {
 		for _, rg := range rgs.Items {
-			ing := a.newIngressFromRouteGroup(rg)
-			if ing != nil {
-				ret = append(ret, ing)
-			}
-
+			ret = append(ret, a.newIngressFromRouteGroup(rg))
 		}
 	}
 	return ret, nil

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -402,6 +402,10 @@ func (a *Adapter) UpdateIngressLoadBalancer(ingress *Ingress, loadBalancerDNSNam
 		return ErrInvalidIngressUpdateParams
 	}
 
+	if loadBalancerDNSName == DefaultClusterLocalDomain {
+		loadBalancerDNSName = ""
+	}
+
 	switch ingress.resourceType {
 	case ingressTypeRouteGroup:
 		return updateRoutegroupLoadBalancer(a.kubeClient, newRouteGroupForKube(ingress), loadBalancerDNSName)

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -71,6 +71,7 @@ const (
 	ingressLoadBalancerTypeAnnotation = "zalando.org/aws-load-balancer-type"
 	ingressHTTP2Annotation            = "zalando.org/aws-load-balancer-http2"
 	ingressClassAnnotation            = "kubernetes.io/ingress.class"
+	clusterLocalDomain                = ".cluster.local"
 )
 
 func getAnnotationsString(annotations map[string]string, key string, defaultValue string) string {

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -71,7 +71,6 @@ const (
 	ingressLoadBalancerTypeAnnotation = "zalando.org/aws-load-balancer-type"
 	ingressHTTP2Annotation            = "zalando.org/aws-load-balancer-http2"
 	ingressClassAnnotation            = "kubernetes.io/ingress.class"
-	clusterLocalDomain                = ".cluster.local"
 )
 
 func getAnnotationsString(annotations map[string]string, key string, defaultValue string) string {

--- a/worker.go
+++ b/worker.go
@@ -339,6 +339,7 @@ func getAllLoadBalancers(certTTL time.Duration, stacks []*aws.Stack) []*loadBala
 func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs CertificatesFinder, certsPerALB int, ingresses []*kubernetes.Ingress) []*loadBalancer {
 	clusterLocalLB := &loadBalancer{
 		clusterLocal: true,
+		ingresses:    make(map[string][]*kubernetes.Ingress),
 	}
 	loadBalancers = append(loadBalancers, clusterLocalLB)
 

--- a/worker.go
+++ b/worker.go
@@ -336,23 +336,15 @@ func getAllLoadBalancers(certTTL time.Duration, stacks []*aws.Stack) []*loadBala
 	return loadBalancers
 }
 
-func getClusterLocal(loadBalancers []*loadBalancer) *loadBalancer {
-	for _, lb := range loadBalancers {
-		if lb.clusterLocal {
-			return lb
-		}
-	}
-
-	return &loadBalancer{
+func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs CertificatesFinder, certsPerALB int, ingresses []*kubernetes.Ingress) []*loadBalancer {
+	clusterLocalLB := &loadBalancer{
 		clusterLocal: true,
 	}
-}
+	loadBalancers = append(loadBalancers, clusterLocalLB)
 
-func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs CertificatesFinder, certsPerALB int, ingresses []*kubernetes.Ingress) []*loadBalancer {
 	for _, ingress := range ingresses {
 		if ingress.ClusterLocal {
-			lb := getClusterLocal(loadBalancers)
-			lb.AddIngress(nil, ingress, math.MaxInt64)
+			clusterLocalLB.AddIngress(nil, ingress, math.MaxInt64)
 			continue
 		}
 


### PR DESCRIPTION
fix #308
- feature: add cluster.local to not create an ALB/NLB
- feature: update ingress/routegroup, in case you switch from public to only cluster.local host rules

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>