### PR TITLE
Add per ingress WAF support

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -477,7 +477,7 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 // All the required resources (listeners and target group) are created in a
 // transactional fashion.
 // Failure to create the stack causes it to be deleted automatically.
-func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, owner, sslPolicy, ipAddressType string, cwAlarms CloudWatchAlarmList, loadBalancerType string, http2 bool) (string, error) {
+func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, owner, sslPolicy, ipAddressType, wafWebACLId string, cwAlarms CloudWatchAlarmList, loadBalancerType string, http2 bool) (string, error) {
 	certARNs := make(map[string]time.Time, len(certificateARNs))
 	for _, arn := range certificateARNs {
 		certARNs[arn] = time.Time{}
@@ -485,6 +485,10 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 
 	if sslPolicy == "" {
 		sslPolicy = a.sslPolicy
+	}
+
+	if wafWebACLId == "" {
+		wafWebACLId = a.wafWebAclId
 	}
 
 	if _, ok := SSLPolicies[sslPolicy]; !ok {
@@ -515,7 +519,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 		loadbalancerType:             loadBalancerType,
 		albLogsS3Bucket:              a.albLogsS3Bucket,
 		albLogsS3Prefix:              a.albLogsS3Prefix,
-		wafWebAclId:                  a.wafWebAclId,
+		wafWebAclId:                  wafWebACLId,
 		cwAlarms:                     cwAlarms,
 		httpRedirectToHTTPS:          a.httpRedirectToHTTPS,
 		nlbCrossZone:                 a.nlbCrossZone,
@@ -526,9 +530,13 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 	return createStack(a.cloudformation, spec)
 }
 
-func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.Time, scheme, sslPolicy, ipAddressType string, cwAlarms CloudWatchAlarmList, loadBalancerType string, http2 bool) (string, error) {
+func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.Time, scheme, sslPolicy, ipAddressType, wafWebACLId string, cwAlarms CloudWatchAlarmList, loadBalancerType string, http2 bool) (string, error) {
 	if _, ok := SSLPolicies[sslPolicy]; !ok {
 		return "", fmt.Errorf("invalid SSLPolicy '%s' defined", sslPolicy)
+	}
+
+	if wafWebACLId == "" {
+		wafWebACLId = a.wafWebAclId
 	}
 
 	spec := &stackSpec{
@@ -554,7 +562,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 		loadbalancerType:             loadBalancerType,
 		albLogsS3Bucket:              a.albLogsS3Bucket,
 		albLogsS3Prefix:              a.albLogsS3Prefix,
-		wafWebAclId:                  a.wafWebAclId,
+		wafWebAclId:                  wafWebACLId,
 		cwAlarms:                     cwAlarms,
 		httpRedirectToHTTPS:          a.httpRedirectToHTTPS,
 		nlbCrossZone:                 a.nlbCrossZone,

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -98,8 +98,10 @@ const (
 	DefaultAlbS3LogsBucket = ""
 	// DefaultAlbS3LogsPrefix is a blank string, and optionally set if desired
 	DefaultAlbS3LogsPrefix = ""
-	DefaultWafWebAclId     = ""
-	DefaultCustomFilter    = ""
+	// DefaultWafWebAclId is a blank string, set if desired.
+	DefaultWafWebAclId = ""
+
+	DefaultCustomFilter = ""
 	// DefaultNLBCrossZone specifies the default configuration for cross
 	// zone load balancing: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#load-balancer-attributes
 	DefaultNLBCrossZone   = false

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -31,7 +31,7 @@ type Stack struct {
 	OwnerIngress      string
 	CWAlarmConfigHash string
 	TargetGroupARN    string
-	WafWebACLId		  string
+	WafWebACLId       string
 	CertificateARNs   map[string]time.Time
 	tags              map[string]string
 }
@@ -388,7 +388,7 @@ func mapToManagedStack(stack *cloudformation.Stack) *Stack {
 		OwnerIngress:      ownerIngress,
 		status:            aws.StringValue(stack.StackStatus),
 		CWAlarmConfigHash: tags[cwAlarmConfigHashTag],
-		WafWebACLId: 	   parameters[parameterLoadBalancerWafWebACLIdParameter],
+		WafWebACLId:       parameters[parameterLoadBalancerWafWebACLIdParameter],
 	}
 }
 

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -31,6 +31,7 @@ type Stack struct {
 	OwnerIngress      string
 	CWAlarmConfigHash string
 	TargetGroupARN    string
+	WafWebACLId		  string
 	CertificateARNs   map[string]time.Time
 	tags              map[string]string
 }
@@ -113,6 +114,7 @@ const (
 	parameterListenerSslPolicyParameter              = "ListenerSslPolicyParameter"
 	parameterIpAddressTypeParameter                  = "IpAddressType"
 	parameterLoadBalancerTypeParameter               = "Type"
+	parameterLoadBalancerWafWebACLIdParameter        = "LoadBalancerWafWebACLIdParameter"
 	parameterHTTP2Parameter                          = "HTTP2"
 )
 
@@ -170,6 +172,7 @@ func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfParam(parameterIpAddressTypeParameter, spec.ipAddressType),
 			cfParam(parameterLoadBalancerTypeParameter, spec.loadbalancerType),
 			cfParam(parameterHTTP2Parameter, fmt.Sprintf("%t", spec.http2)),
+			cfParam(parameterLoadBalancerWafWebACLIdParameter, spec.wafWebAclId),
 		},
 		Tags: []*cloudformation.Tag{
 			cfTag(kubernetesCreatorTag, spec.controllerID),
@@ -226,6 +229,7 @@ func updateStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfParam(parameterIpAddressTypeParameter, spec.ipAddressType),
 			cfParam(parameterLoadBalancerTypeParameter, spec.loadbalancerType),
 			cfParam(parameterHTTP2Parameter, fmt.Sprintf("%t", spec.http2)),
+			cfParam(parameterLoadBalancerWafWebACLIdParameter, spec.wafWebAclId),
 		},
 		Tags: []*cloudformation.Tag{
 			cfTag(kubernetesCreatorTag, spec.controllerID),
@@ -384,6 +388,7 @@ func mapToManagedStack(stack *cloudformation.Stack) *Stack {
 		OwnerIngress:      ownerIngress,
 		status:            aws.StringValue(stack.StackStatus),
 		CWAlarmConfigHash: tags[cwAlarmConfigHashTag],
+		WafWebACLId: 	   parameters[parameterLoadBalancerWafWebACLIdParameter],
 	}
 }
 

--- a/aws/cfmock_test.go
+++ b/aws/cfmock_test.go
@@ -10,6 +10,7 @@ type cfMockOutputs struct {
 	describeStackPages          *apiResponse
 	describeStacks              *apiResponse
 	createStack                 *apiResponse
+	updateStack                 *apiResponse
 	deleteStack                 *apiResponse
 	updateTerminationProtection *apiResponse
 }
@@ -53,6 +54,19 @@ func (m *mockCloudFormationClient) CreateStack(params *cloudformation.CreateStac
 
 func mockCSOutput(stackId string) *cloudformation.CreateStackOutput {
 	return &cloudformation.CreateStackOutput{
+		StackId: aws.String(stackId),
+	}
+}
+
+func (m *mockCloudFormationClient) UpdateStack(params *cloudformation.UpdateStackInput) (*cloudformation.UpdateStackOutput, error) {
+	if out, ok := m.outputs.updateStack.response.(*cloudformation.UpdateStackOutput); ok {
+		return out, m.outputs.updateStack.err
+	}
+	return nil, m.outputs.updateStack.err
+}
+
+func mockUSOutput(stackId string) *cloudformation.UpdateStackOutput {
+	return &cloudformation.UpdateStackOutput{
 		StackId: aws.String(stackId),
 	}
 }

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -14,6 +14,7 @@ type Adapter struct {
 	kubeClient                     client
 	ingressFilters                 []string
 	ingressDefaultSecurityGroup    string
+	ingressWafWebACLId      	   string
 	ingressDefaultSSLPolicy        string
 	ingressDefaultLoadBalancerType string
 	clusterLocalDomain             string
@@ -112,7 +113,7 @@ func (c *ConfigMap) String() string {
 }
 
 // NewAdapter creates an Adapter for Kubernetes using a given configuration.
-func NewAdapter(config *Config, ingressClassFilters []string, ingressDefaultSecurityGroup, ingressDefaultSSLPolicy, ingressDefaultLoadBalancerType, clusterLocalDomain string) (*Adapter, error) {
+func NewAdapter(config *Config, ingressClassFilters []string, ingressDefaultSecurityGroup, ingressWafWebACLId, ingressDefaultSSLPolicy, ingressDefaultLoadBalancerType, clusterLocalDomain string) (*Adapter, error) {
 	if config == nil || config.BaseURL == "" {
 		return nil, ErrInvalidConfiguration
 	}
@@ -124,6 +125,7 @@ func NewAdapter(config *Config, ingressClassFilters []string, ingressDefaultSecu
 		kubeClient:                     c,
 		ingressFilters:                 ingressClassFilters,
 		ingressDefaultSecurityGroup:    ingressDefaultSecurityGroup,
+		ingressWafWebACLId				ingressWafWebACLId, 
 		ingressDefaultSSLPolicy:        ingressDefaultSSLPolicy,
 		ingressDefaultLoadBalancerType: loadBalancerTypesAWSToIngress[ingressDefaultLoadBalancerType],
 		clusterLocalDomain:             clusterLocalDomain,
@@ -212,6 +214,12 @@ func (a *Adapter) parseAnnotations(annotations map[string]string) *Ingress {
 	sslPolicy := getAnnotationsString(annotations, ingressSSLPolicyAnnotation, a.ingressDefaultSSLPolicy)
 	if _, ok := aws.SSLPolicies[sslPolicy]; !ok {
 		sslPolicy = a.ingressDefaultSSLPolicy
+	}
+
+	ingressWafWebACLId :=  getAnnotationsString(annotations, ingressWafWebACLIdAnnotation, a.ingressWafWebACLId)
+	// additionaly check if the waf id is valid, need to add
+	if ingressWafWebACLId != null {
+		ingressWafWebACLId = a.ingressWafWebACLId
 	}
 
 	loadBalancerType := getAnnotationsString(annotations, ingressLoadBalancerTypeAnnotation, a.ingressDefaultLoadBalancerType)

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -268,7 +268,7 @@ func newMetadataForKube(i *Ingress) kubeItemMetadata {
 			ingressSecurityGroupAnnotation:    i.SecurityGroup,
 			ingressSSLPolicyAnnotation:        i.SSLPolicy,
 			ingressALBIPAddressType:           i.IPAddressType,
-			ingressWafWebACLIdAnnotation: 	   i.WafWebACLId,
+			ingressWafWebACLIdAnnotation:      i.WafWebACLId,
 			ingressLoadBalancerTypeAnnotation: loadBalancerTypesAWSToIngress[i.LoadBalancerType],
 		},
 	}

--- a/kubernetes/adapter_test.go
+++ b/kubernetes/adapter_test.go
@@ -24,6 +24,7 @@ var (
 	testIPAddressTypeDefault        = aws.IPAddressTypeIPV4
 	testLoadBalancerTypeIngress     = loadBalancerTypeALB
 	testLoadBalancerTypeAWS         = aws.LoadBalancerTypeApplication
+	testWafWebACLId                 = "zbr-1234"
 )
 
 func TestMappingRoundtrip(tt *testing.T) {
@@ -48,6 +49,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 				IPAddressType:    testIPAddressTypeDefault,
 				LoadBalancerType: testLoadBalancerTypeAWS,
 				resourceType:     ingressTypeIngress,
+				WafWebACLId:      testWafWebACLId,
 			},
 			kubeIngress: &ingress{
 				Metadata: kubeItemMetadata{
@@ -62,6 +64,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 						ingressSSLPolicyAnnotation:        testSSLPolicy,
 						ingressALBIPAddressType:           testIPAddressTypeDefault,
 						ingressLoadBalancerTypeAnnotation: testLoadBalancerTypeIngress,
+						ingressWafWebACLIdAnnotation:      testWafWebACLId,
 					},
 				},
 				Spec: ingressSpec{
@@ -97,6 +100,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 				IPAddressType:    testIPAddressTypeDefault,
 				LoadBalancerType: testLoadBalancerTypeAWS,
 				resourceType:     ingressTypeIngress,
+				WafWebACLId:      testWafWebACLId,
 			},
 			kubeIngress: &ingress{
 				Metadata: kubeItemMetadata{
@@ -111,6 +115,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 						ingressSSLPolicyAnnotation:        testSSLPolicy,
 						ingressALBIPAddressType:           testIPAddressTypeDefault,
 						ingressLoadBalancerTypeAnnotation: testLoadBalancerTypeIngress,
+						ingressWafWebACLIdAnnotation:      testWafWebACLId,
 					},
 				},
 				Spec: ingressSpec{
@@ -146,6 +151,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 				IPAddressType:    testIPAddressTypeDefault,
 				LoadBalancerType: testLoadBalancerTypeAWS,
 				resourceType:     ingressTypeIngress,
+				WafWebACLId:      testWafWebACLId,
 			},
 			kubeIngress: &ingress{
 				Metadata: kubeItemMetadata{
@@ -160,6 +166,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 						ingressSSLPolicyAnnotation:        testSSLPolicy,
 						ingressALBIPAddressType:           testIPAddressTypeDefault,
 						ingressLoadBalancerTypeAnnotation: testLoadBalancerTypeIngress,
+						ingressWafWebACLIdAnnotation:      testWafWebACLId,
 					},
 				},
 				Status: ingressStatus{
@@ -188,6 +195,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 				IPAddressType:    testIPAddressTypeDualStack,
 				LoadBalancerType: testLoadBalancerTypeAWS,
 				resourceType:     ingressTypeIngress,
+				WafWebACLId:      testWafWebACLId,
 			},
 			kubeIngress: &ingress{
 				Metadata: kubeItemMetadata{
@@ -202,6 +210,7 @@ func TestMappingRoundtrip(tt *testing.T) {
 						ingressSSLPolicyAnnotation:        testSSLPolicy,
 						ingressALBIPAddressType:           testIPAddressTypeDualStack,
 						ingressLoadBalancerTypeAnnotation: testLoadBalancerTypeIngress,
+						ingressWafWebACLIdAnnotation:      testWafWebACLId,
 					},
 				},
 				Status: ingressStatus{

--- a/kubernetes/ingress.go
+++ b/kubernetes/ingress.go
@@ -70,6 +70,7 @@ const (
 	ingressSSLPolicyAnnotation        = "zalando.org/aws-load-balancer-ssl-policy"
 	ingressLoadBalancerTypeAnnotation = "zalando.org/aws-load-balancer-type"
 	ingressHTTP2Annotation            = "zalando.org/aws-load-balancer-http2"
+	ingressWafWebACLIdAnnotation      = "zalando.org/aws-waf-web-acl-id"
 	ingressClassAnnotation            = "kubernetes.io/ingress.class"
 )
 

--- a/worker.go
+++ b/worker.go
@@ -31,6 +31,7 @@ type loadBalancer struct {
 	securityGroup    string
 	sslPolicy        string
 	ipAddressType    string
+	wafWebACLId		 string
 	certTTL          time.Duration
 	cwAlarms         aws.CloudWatchAlarmList
 	loadBalancerType string
@@ -91,7 +92,7 @@ func (l *loadBalancer) AddIngress(certificateARNs []string, ingress *kubernetes.
 		l.securityGroup != ingress.SecurityGroup ||
 		l.sslPolicy != ingress.SSLPolicy ||
 		l.loadBalancerType != ingress.LoadBalancerType ||
-		l.http2 != ingress.HTTP2 {
+		l.http2 != ingress.HTTP2 || l.wafWebACLId != ingress.WafWebACLId {
 		return false
 	}
 
@@ -324,6 +325,7 @@ func getAllLoadBalancers(certTTL time.Duration, stacks []*aws.Stack) []*loadBala
 			loadBalancerType: stack.LoadBalancerType,
 			http2:            stack.HTTP2,
 			certTTL:          certTTL,
+			wafWebACLId:	  stack.WafWebACLId,
 		}
 		// initialize ingresses map with existing certificates from the
 		// stack.
@@ -363,7 +365,7 @@ func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs Certific
 				log.Errorf("No certificates found for %v", ingress.Hostnames)
 				continue
 			}
-		}
+		}	
 
 		// try to add ingress to existing ALB stacks until certificate
 		// limit is exeeded.
@@ -402,6 +404,7 @@ func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs Certific
 					ipAddressType:    ingress.IPAddressType,
 					loadBalancerType: ingress.LoadBalancerType,
 					http2:            ingress.HTTP2,
+					wafWebACLId: 	  ingress.WafWebACLId,	
 				},
 			)
 		}
@@ -440,7 +443,7 @@ func createStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 
 	log.Infof("creating stack for certificates %q / ingress %q", certificates, lb.ingresses)
 
-	stackId, err := awsAdapter.CreateStack(certificates, lb.scheme, lb.securityGroup, lb.Owner(), lb.sslPolicy, lb.ipAddressType, lb.cwAlarms, lb.loadBalancerType, lb.http2)
+	stackId, err := awsAdapter.CreateStack(certificates, lb.scheme, lb.securityGroup, lb.Owner(), lb.sslPolicy, lb.ipAddressType, lb.wafWebACLId, lb.cwAlarms, lb.loadBalancerType, lb.http2)
 	if err != nil {
 		if isAlreadyExistsError(err) {
 			lb.stack, err = awsAdapter.GetStack(stackId)
@@ -459,7 +462,7 @@ func updateStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 
 	log.Infof("updating %q stack for %d certificates / %d ingresses", lb.scheme, len(certificates), len(lb.ingresses))
 
-	stackId, err := awsAdapter.UpdateStack(lb.stack.Name, certificates, lb.scheme, lb.sslPolicy, lb.ipAddressType, lb.cwAlarms, lb.loadBalancerType, lb.http2)
+	stackId, err := awsAdapter.UpdateStack(lb.stack.Name, certificates, lb.scheme, lb.sslPolicy, lb.ipAddressType, lb.wafWebACLId, lb.cwAlarms, lb.loadBalancerType, lb.http2)
 	if isNoUpdatesToBePerformedError(err) {
 		log.Debugf("stack(%q) is already up to date", certificates)
 	} else if err != nil {

--- a/worker.go
+++ b/worker.go
@@ -31,7 +31,7 @@ type loadBalancer struct {
 	securityGroup    string
 	sslPolicy        string
 	ipAddressType    string
-	wafWebACLId		 string
+	wafWebACLId      string
 	certTTL          time.Duration
 	cwAlarms         aws.CloudWatchAlarmList
 	loadBalancerType string
@@ -325,7 +325,7 @@ func getAllLoadBalancers(certTTL time.Duration, stacks []*aws.Stack) []*loadBala
 			loadBalancerType: stack.LoadBalancerType,
 			http2:            stack.HTTP2,
 			certTTL:          certTTL,
-			wafWebACLId:	  stack.WafWebACLId,
+			wafWebACLId:      stack.WafWebACLId,
 		}
 		// initialize ingresses map with existing certificates from the
 		// stack.
@@ -365,7 +365,7 @@ func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs Certific
 				log.Errorf("No certificates found for %v", ingress.Hostnames)
 				continue
 			}
-		}	
+		}
 
 		// try to add ingress to existing ALB stacks until certificate
 		// limit is exeeded.
@@ -404,7 +404,7 @@ func matchIngressesToLoadBalancers(loadBalancers []*loadBalancer, certs Certific
 					ipAddressType:    ingress.IPAddressType,
 					loadBalancerType: ingress.LoadBalancerType,
 					http2:            ingress.HTTP2,
-					wafWebACLId: 	  ingress.WafWebACLId,	
+					wafWebACLId:      ingress.WafWebACLId,
 				},
 			)
 		}

--- a/worker_test.go
+++ b/worker_test.go
@@ -118,6 +118,26 @@ func TestAddIngress(tt *testing.T) {
 			maxCerts: 1,
 			added:    false,
 		},
+		{
+			name: "wafacl id not matching",
+			loadBalancer: &loadBalancer{
+				wafWebACLId: "WAFZXX",
+			},
+			ingress: &kubernetes.Ingress{
+				WafWebACLId: "WAFZXC",
+			},
+			added: false,
+		},
+		{
+			name: "wafacl id not matching",
+			loadBalancer: &loadBalancer{
+				wafWebACLId: aws.DefaultWafWebAclId,
+			},
+			ingress: &kubernetes.Ingress{
+				WafWebACLId: "WAFZXC",
+			},
+			added: false,
+		},
 	} {
 		tt.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.loadBalancer.AddIngress(test.certificateARNs, test.ingress, test.maxCerts), test.added)


### PR DESCRIPTION
Add the ability to set a 'WAF Id' in ingress configuration as an annotation #238

WAF ACL id is set in annotations like below:
```zalando.org/aws-load-balancer-waf-id: "foobar"```

This would create a new loadbalancer and associate WAF if there is no loadbalancer with the same waf attached.