### PR TITLE
Show version on boot

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -187,7 +187,7 @@ func loadDurationFromEnv(varName string, dest *time.Duration) error {
 }
 
 func main() {
-	log.Infof("starting %s", os.Args[0])
+	log.Infof("starting %s %s", os.Args[0], version)
 	var (
 		awsAdapter  *aws.Adapter
 		kubeAdapter *kubernetes.Adapter


### PR DESCRIPTION
This makes it easier to see what version is running when looking at the K8s logs.
