### PR TITLE
AwsAdapter > Enable `LogDebugWithRequestErrors` when debug mode is enabled

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -149,10 +149,11 @@ var (
 	}
 )
 
-var configProvider = defaultConfigProvider
-
-func defaultConfigProvider() client.ConfigProvider {
+func newConfigProvider(debug bool) client.ConfigProvider {
 	cfg := aws.NewConfig().WithMaxRetries(3)
+	if debug {
+		cfg = cfg.WithLogLevel(aws.LogDebugWithRequestErrors)
+	}
 	cfg = cfg.WithHTTPClient(instrumented_http.NewClient(cfg.HTTPClient, nil))
 	opts := session.Options{
 		SharedConfigState: session.SharedConfigEnable,
@@ -165,8 +166,8 @@ func defaultConfigProvider() client.ConfigProvider {
 // Before returning there is a discovery process for VPC and EC2 details. It tries to find the Auto Scaling Group and
 // Security Group that should be used for newly created Load Balancers. If any of those critical steps fail
 // an appropriate error is returned.
-func NewAdapter(newControllerID string) (adapter *Adapter, err error) {
-	p := configProvider()
+func NewAdapter(newControllerID string, debug bool) (adapter *Adapter, err error) {
+	p := newConfigProvider(debug)
 	adapter = &Adapter{
 		ec2:                 ec2.New(p),
 		elbv2:               elbv2.New(p),

--- a/controller.go
+++ b/controller.go
@@ -208,7 +208,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	awsAdapter, err = aws.NewAdapter(controllerID)
+	awsAdapter, err = aws.NewAdapter(controllerID, debugFlag)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This makes it easier to debug issues, for example with [IMDSv2](https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/309).