### PR TITLE
Change default cert TTL to 1 hour

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -25,7 +25,7 @@ const (
 	defaultDisableSNISupport      = "false"
 	defaultInstrumentedHttpClient = "false"
 	defaultHTTPRedirectToHTTPS    = "false"
-	defaultCertTTL                = "30m"
+	defaultCertTTL                = "1h"
 	customTagFilterEnvVarName     = "CUSTOM_FILTERS"
 )
 


### PR DESCRIPTION
As discussed in https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/339

There is already a way for us to increase the TTL:
```go
kingpin.Flag("cert-ttl-timeout", "sets the timeout of how long a certificate is kept on an old ALB to be decommissioned.").
   Default(defaultCertTTL).DurationVar(&certTTL)
```

This TTL is used to remove the old LB stack. It was set to 30 minutes and this PR will change it to 1 hour.

On our deployment, we will further increase this to 24 hours.