### PR TITLE
Ensure that WAF ID is really optional on the stack.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ vendor/
 Dockerfile.upstream
 /.GOPATH
 /bin
+profile.cov

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ default: build.local
 ## clean: cleans the binary
 clean:
 	rm -rf build
+	rm -rf profile.cov
 
 ## test: runs go test
 test:

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -83,17 +83,12 @@ func generateTemplate(spec *stackSpec) (string, error) {
 			Description: "H2 Enabled",
 			Default:     "true",
 		},
-		parameterLoadBalancerWAFWebACLIDParameter: &cloudformation.Parameter{
-			Type:        "String",
-			Description: "WAF Id or ARN",
-			Default:     "",
-		},
 	}
 
 	if spec.wafWebAclId != "" {
 		template.Parameters[parameterLoadBalancerWAFWebACLIDParameter] = &cloudformation.Parameter{
 			Type:        "String",
-			Description: "Associated WAF ID.",
+			Description: "Associated WAF ID or ARN.",
 		}
 	}
 


### PR DESCRIPTION
This fixes #331 by ensuring that the WAF ID parameter is ONLY set on the stack when the ID is not empty.

We accidentally set it optionally and by default in #341 