### PR TITLE
Enable Github Native dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Enables the Github native version of dependabot as documented here: https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically

Not completely sure how it's different from the @dependabot we currently have enabled. Let's try it out!