### PR TITLE
Add support for setting additional stack tags

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -50,6 +50,7 @@ type Adapter struct {
 	singleInstances            map[string]*instanceDetails
 	obsoleteInstances          []string
 	stackTerminationProtection bool
+	stackTags                  map[string]string
 	controllerID               string
 	sslPolicy                  string
 	ipAddressType              string
@@ -280,6 +281,13 @@ func (a *Adapter) WithSslPolicy(policy string) *Adapter {
 // the stack termination protection value.
 func (a *Adapter) WithStackTerminationProtection(terminationProtection bool) *Adapter {
 	a.stackTerminationProtection = terminationProtection
+	return a
+}
+
+// WithStackTags returns the receiver adapter after setting the stackTags
+// value.
+func (a *Adapter) WithStackTags(tags map[string]string) *Adapter {
+	a.stackTags = tags
 	return a
 }
 
@@ -519,6 +527,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 		nlbCrossZone:                 a.nlbCrossZone,
 		nlbHTTPEnabled:               a.nlbHTTPEnabled,
 		http2:                        http2,
+		tags:                         a.stackTags,
 	}
 
 	return createStack(a.cloudformation, spec)
@@ -559,6 +568,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 		nlbCrossZone:                 a.nlbCrossZone,
 		nlbHTTPEnabled:               a.nlbHTTPEnabled,
 		http2:                        http2,
+		tags:                         a.stackTags,
 	}
 
 	return updateStack(a.cloudformation, spec)

--- a/controller.go
+++ b/controller.go
@@ -47,6 +47,7 @@ var (
 	disableInstrumentedHttpClient bool
 	certTTL                       time.Duration
 	stackTerminationProtection    bool
+	additionalStackTags           = make(map[string]string)
 	idleConnectionTimeout         time.Duration
 	ingressClassFilters           string
 	controllerID                  string
@@ -89,6 +90,8 @@ func loadSettings() error {
 		Default(defaultInstrumentedHttpClient).BoolVar(&disableInstrumentedHttpClient)
 	kingpin.Flag("stack-termination-protection", "enables stack termination protection for the stacks managed by the controller.").
 		Default("false").BoolVar(&stackTerminationProtection)
+	kingpin.Flag("additional-stack-tags", "set additional custom tags on the Cloudformation Stacks managed by the controller.").
+		StringMapVar(&additionalStackTags)
 	kingpin.Flag("cert-ttl-timeout", "sets the timeout of how long a certificate is kept on an old ALB to be decommissioned.").
 		Default(defaultCertTTL).DurationVar(&certTTL)
 	kingpin.Flag("health-check-path", "sets the health check path for the created target groups").
@@ -231,7 +234,8 @@ func main() {
 		WithHTTPRedirectToHTTPS(httpRedirectToHTTPS).
 		WithNLBCrossZone(nlbCrossZone).
 		WithNLBHTTPEnabled(nlbHTTPEnabled).
-		WithCustomFilter(customFilter)
+		WithCustomFilter(customFilter).
+		WithStackTags(additionalStackTags)
 
 	log.Debug("certs.NewCachingProvider")
 	certificatesProvider, err := certs.NewCachingProvider(


### PR DESCRIPTION
Adds a flag `--additional-stack-tags key=val` which allows setting additional custom tags on the CF stacks managed by the controller.

This can be useful if your infrastructure relies on additional tags e.g. for cost reporting or permissions. Zalando use case is to add `InfrastructureComponent=true` tags such that we can prevent non-admin users from touching resources with those tags.