### PR TITLE
UpdateStack(): don't reset the security group

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -547,7 +547,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 	return createStack(a.cloudformation, spec)
 }
 
-func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.Time, scheme, owner, sslPolicy, ipAddressType, wafWebACLID string, cwAlarms CloudWatchAlarmList, loadBalancerType string, http2 bool) (string, error) {
+func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.Time, scheme, securityGroup, owner, sslPolicy, ipAddressType, wafWebACLID string, cwAlarms CloudWatchAlarmList, loadBalancerType string, http2 bool) (string, error) {
 	if _, ok := SSLPolicies[sslPolicy]; !ok {
 		return "", fmt.Errorf("invalid SSLPolicy '%s' defined", sslPolicy)
 	}
@@ -557,7 +557,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 		scheme:          scheme,
 		ownerIngress:    owner,
 		certificateARNs: certificateARNs,
-		securityGroupID: a.SecurityGroupID(),
+		securityGroupID: securityGroup,
 		subnets:         a.FindLBSubnets(scheme),
 		vpcID:           a.VpcID(),
 		clusterID:       a.ClusterID(),

--- a/worker.go
+++ b/worker.go
@@ -505,7 +505,7 @@ func updateStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 
 	log.Infof("updating %q stack for %d certificates / %d ingresses", lb.scheme, len(certificates), len(lb.ingresses))
 
-	stackId, err := awsAdapter.UpdateStack(lb.stack.Name, certificates, lb.scheme, lb.Owner(), lb.sslPolicy, lb.ipAddressType, lb.wafWebACLID, lb.cwAlarms, lb.loadBalancerType, lb.http2)
+	stackId, err := awsAdapter.UpdateStack(lb.stack.Name, certificates, lb.scheme, lb.securityGroup, lb.Owner(), lb.sslPolicy, lb.ipAddressType, lb.wafWebACLID, lb.cwAlarms, lb.loadBalancerType, lb.http2)
 	if isNoUpdatesToBePerformedError(err) {
 		log.Debugf("stack(%q) is already up to date", certificates)
 	} else if err != nil {


### PR DESCRIPTION
`CreateStack` and `UpdateStack` used different values for the SG parameter, causing it to reset the configuration. Fix by making `UpdateStack` use the SG from the ingress if set, not the default one.