### PR TITLE
Fix detaching of target groups

### DIFF
--- a/aws/asg_test.go
+++ b/aws/asg_test.go
@@ -228,8 +228,14 @@ func TestAttach(t *testing.T) {
 				detachLoadBalancerTargetGroups: R(nil, nil),
 			},
 			elbv2Response: elbv2MockOutputs{
-				describeTargetGroups: R(nil, nil),
-				describeTags:         R(nil, errDummy),
+				describeTargetGroups: R(&elbv2.DescribeTargetGroupsOutput{
+					TargetGroups: []*elbv2.TargetGroup{
+						{
+							TargetGroupArn: aws.String("foo"),
+						},
+					},
+				}, nil),
+				describeTags: R(nil, errDummy),
 			},
 			wantError: true,
 		},

--- a/controller.go
+++ b/controller.go
@@ -303,7 +303,7 @@ func main() {
 	log.Infof("Default LoadBalancer type: %s", loadBalancerType)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go handleTerminationSignals(cancel, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go handleTerminationSignals(cancel, syscall.SIGTERM, syscall.SIGQUIT)
 	go serveMetrics(metricsAddress)
 	startPolling(
 		ctx,


### PR DESCRIPTION
In some cases the Autoscaling groups can end up being configured with target groups that no longer exists. If that happens we have logic for cleaning up those target groups to prevent other autoscaling group changes from being blocked.

This fixes the logic slightly such that it doesn't try to get the tags of non-existing target groups which would fail and thus prevent the controller from detaching the non-existing target groups.