### PR TITLE
✨ adding parameter for Health-Check Timeout

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -41,6 +41,7 @@ type Adapter struct {
 	healthCheckPath            string
 	healthCheckPort            uint
 	healthCheckInterval        time.Duration
+	healthCheckTimeout         time.Duration
 	targetPort                 uint
 	creationTimeout            time.Duration
 	idleConnectionTimeout      time.Duration
@@ -80,6 +81,7 @@ const (
 	DefaultHealthCheckPort           = 9999
 	DefaultTargetPort                = 9999
 	DefaultHealthCheckInterval       = 10 * time.Second
+	DefaultHealthCheckTimeout        = 5 * time.Second
 	DefaultCertificateUpdateInterval = 30 * time.Minute
 	DefaultCreationTimeout           = 5 * time.Minute
 	DefaultIdleConnectionTimeout     = 1 * time.Minute
@@ -190,6 +192,7 @@ func NewAdapter(clusterID, newControllerID, vpcID string, debug, disableInstrume
 		healthCheckPort:     DefaultHealthCheckPort,
 		targetPort:          DefaultTargetPort,
 		healthCheckInterval: DefaultHealthCheckInterval,
+		healthCheckTimeout:  DefaultHealthCheckTimeout,
 		creationTimeout:     DefaultCreationTimeout,
 		ec2Details:          make(map[string]*instanceDetails),
 		singleInstances:     make(map[string]*instanceDetails),
@@ -245,6 +248,13 @@ func (a *Adapter) WithTargetPort(port uint) *Adapter {
 // the resources created by the adapter
 func (a *Adapter) WithHealthCheckInterval(interval time.Duration) *Adapter {
 	a.healthCheckInterval = interval
+	return a
+}
+
+// WithHealthCheckTimeout returns the receiver adapter after changing the health check timeout that will be used by
+// the resources created by the adapter
+func (a *Adapter) WithHealthCheckTimeout(timeout time.Duration) *Adapter {
+	a.healthCheckTimeout = timeout
 	return a
 }
 
@@ -528,6 +538,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 			path:     a.healthCheckPath,
 			port:     a.healthCheckPort,
 			interval: a.healthCheckInterval,
+			timeout:  a.healthCheckTimeout,
 		},
 		targetPort:                        a.targetPort,
 		timeoutInMinutes:                  uint(a.creationTimeout.Minutes()),
@@ -570,6 +581,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 			path:     a.healthCheckPath,
 			port:     a.healthCheckPort,
 			interval: a.healthCheckInterval,
+			timeout:  a.healthCheckTimeout,
 		},
 		targetPort:                        a.targetPort,
 		timeoutInMinutes:                  uint(a.creationTimeout.Minutes()),

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -108,6 +108,7 @@ const (
 	parameterTargetGroupHealthCheckPathParameter     = "TargetGroupHealthCheckPathParameter"
 	parameterTargetGroupHealthCheckPortParameter     = "TargetGroupHealthCheckPortParameter"
 	parameterTargetGroupHealthCheckIntervalParameter = "TargetGroupHealthCheckIntervalParameter"
+	parameterTargetGroupHealthCheckTimeoutParameter  = "TargetGroupHealthCheckTimeoutParameter"
 	parameterTargetTargetPortParameter               = "TargetGroupTargetPortParameter"
 	parameterTargetGroupVPCIDParameter               = "TargetGroupVPCIDParameter"
 	parameterListenerCertificatesParameter           = "ListenerCertificatesParameter"
@@ -153,6 +154,7 @@ type healthCheck struct {
 	path     string
 	port     uint
 	interval time.Duration
+	timeout  time.Duration
 }
 
 func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (string, error) {
@@ -204,6 +206,7 @@ func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfParam(parameterTargetGroupHealthCheckPathParameter, spec.healthCheck.path),
 			cfParam(parameterTargetGroupHealthCheckPortParameter, fmt.Sprintf("%d", spec.healthCheck.port)),
 			cfParam(parameterTargetGroupHealthCheckIntervalParameter, fmt.Sprintf("%.0f", spec.healthCheck.interval.Seconds())),
+			cfParam(parameterTargetGroupHealthCheckTimeoutParameter, fmt.Sprintf("%.0f", spec.healthCheck.timeout.Seconds())),
 		)
 	}
 
@@ -269,6 +272,7 @@ func updateStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (st
 			cfParam(parameterTargetGroupHealthCheckPathParameter, spec.healthCheck.path),
 			cfParam(parameterTargetGroupHealthCheckPortParameter, fmt.Sprintf("%d", spec.healthCheck.port)),
 			cfParam(parameterTargetGroupHealthCheckIntervalParameter, fmt.Sprintf("%.0f", spec.healthCheck.interval.Seconds())),
+			cfParam(parameterTargetGroupHealthCheckTimeoutParameter, fmt.Sprintf("%.0f", spec.healthCheck.timeout.Seconds())),
 		)
 	}
 

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -59,6 +59,11 @@ func generateTemplate(spec *stackSpec) (string, error) {
 			Description: "The healthcheck interval",
 			Default:     "10",
 		},
+		parameterTargetGroupHealthCheckTimeoutParameter: &cloudformation.Parameter{
+			Type:        "Number",
+			Description: "The healthcheck timeout",
+			Default:     "5",
+		},
 		parameterTargetGroupVPCIDParameter: &cloudformation.Parameter{
 			Type:        "AWS::EC2::VPC::Id",
 			Description: "The VPCID for the TargetGroup",
@@ -276,6 +281,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 		TargetGroupAttributes: &targetGroupAttributes,
 
 		HealthCheckIntervalSeconds: cloudformation.Ref(parameterTargetGroupHealthCheckIntervalParameter).Integer(),
+		HealthCheckTimeoutSeconds:  cloudformation.Ref(parameterTargetGroupHealthCheckTimeoutParameter).Integer(),
 		HealthCheckPath:            cloudformation.Ref(parameterTargetGroupHealthCheckPathParameter).String(),
 		HealthCheckPort:            cloudformation.Ref(parameterTargetGroupHealthCheckPortParameter).String(),
 		HealthCheckProtocol:        cloudformation.String("HTTP"),

--- a/cloudformation.md
+++ b/cloudformation.md
@@ -39,6 +39,7 @@ behavior and set of resources created. Each one of the following parameters shou
 | TargetGroupHealthCheckPathParameter     	| The health check path for the TargetGroup                  	| No       	| /kube-system/healthz 	|
 | TargetGroupHealthCheckPortParameter     	| The health check port for the TargetGroup                  	| No       	| 9999                 	|
 | TargetGroupHealthCheckIntervalParameter 	| The health check polling interval for the TargetGroup      	| No       	| 10 secs              	|
+| TargetGroupHealthCheckTimeoutParameter 	| The health check polling timeout for the TargetGroup      	| No       	| 5 secs              	|
 | ListenerCertificateParameter            	| The HTTPS Listener certificate ARN (IAM/ACM)               	| No       	| No HTTPS Listener    	|
 
 ### Outputs

--- a/controller.go
+++ b/controller.go
@@ -41,6 +41,7 @@ var (
 	healthCheckPath               string
 	healthCheckPort               uint
 	healthCheckInterval           time.Duration
+	healthCheckTimeout            time.Duration
 	targetPort                    uint
 	metricsAddress                string
 	disableSNISupport             bool
@@ -105,6 +106,8 @@ func loadSettings() error {
 		Default(strconv.FormatUint(aws.DefaultTargetPort, 10)).UintVar(&targetPort)
 	kingpin.Flag("health-check-interval", "sets the health check interval for the created target groups. The flag accepts a value acceptable to time.ParseDuration").
 		Default(aws.DefaultHealthCheckInterval.String()).DurationVar(&healthCheckInterval)
+	kingpin.Flag("health-check-timeout", "sets the health check timeout for the created target groups. The flag accepts a value acceptable to time.ParseDuration").
+		Default(aws.DefaultHealthCheckTimeout.String()).DurationVar(&healthCheckTimeout)
 	kingpin.Flag("idle-connection-timeout", "sets the idle connection timeout of all ALBs. The flag accepts a value acceptable to time.ParseDuration and are between 1s and 4000s.").
 		Default(aws.DefaultIdleConnectionTimeout.String()).DurationVar(&idleConnectionTimeout)
 	kingpin.Flag("deregistration-delay-timeout", "sets the deregistration delay timeout of all target groups.  The flag accepts a value acceptable to time.ParseDuration that is between 1s and 3600s.").
@@ -231,6 +234,7 @@ func main() {
 		WithHealthCheckPath(healthCheckPath).
 		WithHealthCheckPort(healthCheckPort).
 		WithHealthCheckInterval(healthCheckInterval).
+		WithHealthCheckTimeout(healthCheckTimeout).
 		WithTargetPort(targetPort).
 		WithCreationTimeout(creationTimeout).
 		WithStackTerminationProtection(stackTerminationProtection).


### PR DESCRIPTION
The Health-Check Timeout is currently unconfigured, resulting into `5s`

However, in order to reduce the `healthcheck Interval` below `6s` it is necessary to also reduce the `Timeout` as it must be smaller!

Otherwise following exception will occur:

```
Health check interval must be greater than the timeout. (Service: AmazonElasticLoadBalancing; Status Code: 400; Error Code: ValidationError; ...)
```

This adds a paramter that can be configured.