### PR TITLE
ALB Listener rule to deny internal domain requests

### DIFF
--- a/aws/cf.go
+++ b/aws/cf.go
@@ -147,6 +147,9 @@ type stackSpec struct {
 	nlbCrossZone                      bool
 	nlbHTTPEnabled                    bool
 	http2                             bool
+	denyInternalDomains               bool
+	denyInternalDomainsResponse       denyResp
+	internalDomains                   []string
 	tags                              map[string]string
 }
 
@@ -155,6 +158,12 @@ type healthCheck struct {
 	port     uint
 	interval time.Duration
 	timeout  time.Duration
+}
+
+type denyResp struct {
+	statusCode  int
+	contentType string
+	body        string
 }
 
 func createStack(svc cloudformationiface.CloudFormationAPI, spec *stackSpec) (string, error) {

--- a/controller.go
+++ b/controller.go
@@ -27,6 +27,7 @@ const (
 	defaultHTTPRedirectToHTTPS    = "false"
 	defaultCertTTL                = "1h"
 	customTagFilterEnvVarName     = "CUSTOM_FILTERS"
+	defaultInternalDomains        = "*.ingress.cluster.local"
 )
 
 var (
@@ -74,6 +75,11 @@ var (
 	nlbCrossZone                  bool
 	nlbHTTPEnabled                bool
 	ingressAPIVersion             string
+	internalDomains               []string
+	denyInternalDomains           bool
+	denyInternalRespBody          string
+	denyInternalRespContentType   string
+	denyInternalRespStatusCode    int
 )
 
 func loadSettings() error {
@@ -148,6 +154,16 @@ func loadSettings() error {
 		Default("false").BoolVar(&nlbHTTPEnabled)
 	kingpin.Flag("ingress-api-version", "APIversion used for listing/updating ingresses.").
 		Default(kubernetes.IngressAPIVersionNetworking).EnumVar(&ingressAPIVersion, kubernetes.IngressAPIVersionNetworking, kubernetes.IngressAPIVersionExtensions)
+	kingpin.Flag("deny-internal-domains", "Sets a rule on ALB's Listeners that denies requests with the Host header as a internal domain. Domains can be set with the -internal-domains flag.").
+		Default("false").BoolVar(&denyInternalDomains)
+	kingpin.Flag("internal-domains", "Define the internal domains to be blocked when -deny-internal-domains is set to true. Set it multiple times for multiple domains. The maximum size of each name is 128 characters. The following wildcard characters are supported: * (matches 0 or more characters) and ? (matches exactly 1 character).").
+		Default(defaultInternalDomains).StringsVar(&internalDomains)
+	kingpin.Flag("deny-internal-domains-response", "Defines the response body for a request identified as to an internal domain when -deny-internal-domains is set.").
+		Default("Unauthorized").StringVar(&denyInternalRespBody)
+	kingpin.Flag("deny-internal-domains-response-content-type", "Defines the response conten-type for a request identified as to an internal domain when -deny-internal-domains is set.").
+		Default("text/plain").StringVar(&denyInternalRespContentType)
+	kingpin.Flag("deny-internal-domains-response-status-code", "Defines the response status code for a request identified as to an internal domain when -deny-internal-domains is set.").
+		Default("401").IntVar(&denyInternalRespStatusCode)
 	kingpin.Parse()
 
 	blacklistCertArnMap = make(map[string]bool)
@@ -249,7 +265,12 @@ func main() {
 		WithNLBCrossZone(nlbCrossZone).
 		WithNLBHTTPEnabled(nlbHTTPEnabled).
 		WithCustomFilter(customFilter).
-		WithStackTags(additionalStackTags)
+		WithStackTags(additionalStackTags).
+		WithInternalDomains(internalDomains).
+		WithDenyInternalDomains(denyInternalDomains).
+		WithInternalDomainsDenyResponse(denyInternalRespBody).
+		WithInternalDomainsDenyResponseStatusCode(denyInternalRespStatusCode).
+		WithInternalDomainsDenyResponseContenType(denyInternalRespContentType)
 
 	log.Debug("certs.NewCachingProvider")
 	certificatesProvider, err := certs.NewCachingProvider(

--- a/controller.go
+++ b/controller.go
@@ -27,7 +27,6 @@ const (
 	defaultHTTPRedirectToHTTPS    = "false"
 	defaultCertTTL                = "1h"
 	customTagFilterEnvVarName     = "CUSTOM_FILTERS"
-	defaultInternalDomains        = "*.ingress.cluster.local"
 )
 
 var (
@@ -80,6 +79,7 @@ var (
 	denyInternalRespBody          string
 	denyInternalRespContentType   string
 	denyInternalRespStatusCode    int
+	defaultInternalDomains        = fmt.Sprintf("*%s", kubernetes.DefaultClusterLocalDomain)
 )
 
 func loadSettings() error {


### PR DESCRIPTION
This commit addresses #402. It adds the following new configuration
flags:
  - internal-domains
  - deny-internal-domains
  - deny-internal-domains-response
  - deny-internal-domains-response-content-type
  - deny-internal-domains-response-status-code

The main flag is the `deny-internal-domains`, a boolean that enables and
disables the feature. The other flags allow to set the internal domains
that will be protected as well as the response that will be returned.
Defaults are also set: an HTTP `text/plain` `401 - Unauthorized`
response for the `*.ingress.cluster.local` domain.

The ALB cloudformation template will add a
[`AWS::ElasticLoadBalancingV2::ListenerRule`][0] resource, configured
with the [condition][1] values from the `internal-domains` and the
[action `fixedresponseconfig`][2] with the respective response
`deny-internal-domains-response` flags.

[0]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html
[1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-hostheaderconfig.html
[2]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-action.html#cfn-elasticloadbalancingv2-listenerrule-action-fixedresponseconfig

Signed-off-by: Jonathan Juares Beber <jonathanbeber@gmail.com>