### PR TITLE
Apply rule creation just on ALBs

### DIFF
--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -151,7 +151,8 @@ func generateTemplate(spec *stackSpec) (string, error) {
 			Port:            cloudformation.Integer(80),
 			Protocol:        cloudformation.String(protocol),
 		})
-		if spec.denyInternalDomains {
+		// Just ALBs support Rules
+		if spec.denyInternalDomains && spec.loadbalancerType == LoadBalancerTypeApplication {
 			template.AddResource(
 				"HTTPRuleBlockInternalTraffic",
 				generateDenyInternalTrafficRule(
@@ -193,7 +194,8 @@ func generateTemplate(spec *stackSpec) (string, error) {
 			Protocol:        cloudformation.String(tlsProtocol),
 			SslPolicy:       cloudformation.Ref(parameterListenerSslPolicyParameter).String(),
 		})
-		if spec.denyInternalDomains {
+		// Just ALBs support Rules
+		if spec.denyInternalDomains && spec.loadbalancerType == LoadBalancerTypeApplication {
 			template.AddResource(
 				"HTTPSRuleBlockInternalTraffic",
 				generateDenyInternalTrafficRule(

--- a/aws/cf_template_test.go
+++ b/aws/cf_template_test.go
@@ -341,6 +341,20 @@ func TestGenerateTemplate(t *testing.T) {
 				require.NotContains(t, template.Resources, "HTTPRuleBlockInternalTraffic")
 			},
 		},
+		{
+			name: "Does not create deny internal traffic rule on NLBs",
+			spec: &stackSpec{
+				loadbalancerType: LoadBalancerTypeNetwork,
+				certificateARNs:  map[string]time.Time{"domain.company.com": time.Now()},
+				nlbHTTPEnabled:   true,
+
+				denyInternalDomains: true,
+			},
+			validate: func(t *testing.T, template *cloudformation.Template) {
+				require.NotContains(t, template.Resources, "HTTPSRuleBlockInternalTraffic")
+				require.NotContains(t, template.Resources, "HTTPRuleBlockInternalTraffic")
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			generated, err := generateTemplate(test.spec)


### PR DESCRIPTION
The #400 PR added rules to deny internal traffic, and in its docs it
even stated that NLBs do not support this feature. But the code didn't
check for the load balancer type. This commit adds the logic to apply
the rule creation just for ALBs.