### PR TITLE
Add the ability to use an HTTPS target

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,9 @@ listening on that port.
 If you want to change the default ports, you can control it using the
 `-target-port` and `-health-check-port` flags.
 
+If you want to use an HTTPS enabled target port, use the `-target-https` flag.
+This will only affect ALBs, NLBs ignore this flag.
+
 ## HTTP to HTTPS Redirection
 
 By default, the controller will expose both HTTP and HTTPS ports on the load balancer, and forward both listeners to the target port. Setting the flag `-redirect-http-to-https` will instead configure the HTTP listener to emit a 301 redirect for any request received, with the destination location being the same URL but with the HTTPS scheme vs. HTTP. The specifics are described in the [relevant aws documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-redirectconfig.html).

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -43,6 +43,7 @@ type Adapter struct {
 	healthCheckInterval         time.Duration
 	healthCheckTimeout          time.Duration
 	targetPort                  uint
+	targetHTTPS                 bool
 	creationTimeout             time.Duration
 	idleConnectionTimeout       time.Duration
 	deregistrationDelayTimeout  time.Duration
@@ -246,6 +247,12 @@ func (a *Adapter) WithHealthCheckPort(port uint) *Adapter {
 // the resources created by the adapter
 func (a *Adapter) WithTargetPort(port uint) *Adapter {
 	a.targetPort = port
+	return a
+}
+
+// WithTargetHTTPS returns the receiver adapter after specifying the target port will use HTTPS
+func (a *Adapter) WithTargetHTTPS(https bool) *Adapter {
+	a.targetHTTPS = https
 	return a
 }
 
@@ -638,6 +645,7 @@ func (a *Adapter) UpdateStack(stackName string, certificateARNs map[string]time.
 			timeout:  a.healthCheckTimeout,
 		},
 		targetPort:                        a.targetPort,
+		targetHTTPS:                       a.targetHTTPS,
 		timeoutInMinutes:                  uint(a.creationTimeout.Minutes()),
 		stackTerminationProtection:        a.stackTerminationProtection,
 		idleConnectionTimeoutSeconds:      uint(a.idleConnectionTimeout.Seconds()),

--- a/aws/adapter_test.go
+++ b/aws/adapter_test.go
@@ -910,3 +910,20 @@ func TestNonTargetedASGs(t *testing.T) {
 		})
 	}
 }
+
+func TestWithTargetPort(t *testing.T) {
+	t.Run("WithTargetPort sets the targetPort property", func(t *testing.T) {
+		a := Adapter{}
+		port := uint(9977)
+		b := a.WithTargetPort(port)
+		require.Equal(t, port, b.targetPort)
+	})
+}
+
+func TestWithTargetHTTPS(t *testing.T) {
+	t.Run("WithTargetHTTPS sets the targetHTTPS property", func(t *testing.T) {
+		a := Adapter{}
+		b := a.WithTargetHTTPS(true)
+		require.Equal(t, true, b.targetHTTPS)
+	})
+}

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -130,6 +130,7 @@ type stackSpec struct {
 	vpcID                             string
 	healthCheck                       *healthCheck
 	targetPort                        uint
+	targetHTTPS                       bool
 	timeoutInMinutes                  uint
 	customTemplate                    string
 	stackTerminationProtection        bool

--- a/controller.go
+++ b/controller.go
@@ -43,6 +43,7 @@ var (
 	healthCheckInterval           time.Duration
 	healthCheckTimeout            time.Duration
 	targetPort                    uint
+	targetHTTPS                   bool
 	metricsAddress                string
 	disableSNISupport             bool
 	disableInstrumentedHttpClient bool
@@ -110,6 +111,8 @@ func loadSettings() error {
 		Default(strconv.FormatUint(aws.DefaultHealthCheckPort, 10)).UintVar(&healthCheckPort)
 	kingpin.Flag("target-port", "sets the target port for the created target groups").
 		Default(strconv.FormatUint(aws.DefaultTargetPort, 10)).UintVar(&targetPort)
+	kingpin.Flag("target-https", "sets the target protocol to https").
+		Default("false").BoolVar(&targetHTTPS)
 	kingpin.Flag("health-check-interval", "sets the health check interval for the created target groups. The flag accepts a value acceptable to time.ParseDuration").
 		Default(aws.DefaultHealthCheckInterval.String()).DurationVar(&healthCheckInterval)
 	kingpin.Flag("health-check-timeout", "sets the health check timeout for the created target groups. The flag accepts a value acceptable to time.ParseDuration").
@@ -252,6 +255,7 @@ func main() {
 		WithHealthCheckInterval(healthCheckInterval).
 		WithHealthCheckTimeout(healthCheckTimeout).
 		WithTargetPort(targetPort).
+		WithTargetHTTPS(targetHTTPS).
 		WithCreationTimeout(creationTimeout).
 		WithStackTerminationProtection(stackTerminationProtection).
 		WithIdleConnectionTimeout(idleConnectionTimeout).


### PR DESCRIPTION
This adds a boolean flag called `target-https` which will set the
protocol used on a target group to HTTPS.

**Motivation**

AWS VPC networking does prevent external targets from sniffing the wire,
but if the target is a proxy listening on the hostNetwork, any other pod
deployed to that node that is also using the hostNetwork can read the traffic
unencrypted. In cases where end-to-end encryption is expected or
desirable, this allows for that option.