### PR TITLE
:bug: Add possible HTTPS support on new stacks

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -595,6 +595,7 @@ func (a *Adapter) CreateStack(certificateARNs []string, scheme, securityGroup, o
 			timeout:  a.healthCheckTimeout,
 		},
 		targetPort:                        a.targetPort,
+		targetHTTPS:                       a.targetHTTPS,
 		timeoutInMinutes:                  uint(a.creationTimeout.Minutes()),
 		stackTerminationProtection:        a.stackTerminationProtection,
 		idleConnectionTimeoutSeconds:      uint(a.idleConnectionTimeout.Seconds()),


### PR DESCRIPTION
I missed the different stackSpec setup for the CreateStack method, and
only added for UpdateStack. Side effect is that new stacks would always
still have a HTTP target group, but stack updates would change it to
HTTPS if specified.

Signed-off-by: Jeremy Huntwork <jhuntwork@lightcubesolutions.com>