### PR TITLE
HTTPListener uses HTTP protocol when target is HTTPS

### DIFF
--- a/aws/cf_template_test.go
+++ b/aws/cf_template_test.go
@@ -367,6 +367,9 @@ func TestGenerateTemplate(t *testing.T) {
 				require.True(t, ok, "couldn't convert resource to ElasticLoadBalancingV2TargetGroup")
 				require.Equal(t, cloudformation.String("HTTPS"), tg.Protocol)
 				require.Equal(t, cloudformation.String("HTTPS"), tg.HealthCheckProtocol)
+
+				listener := template.Resources["HTTPListener"].Properties.(*cloudformation.ElasticLoadBalancingV2Listener)
+				require.Equal(t, cloudformation.String("HTTP"), listener.Protocol)
 			},
 		},
 		{


### PR DESCRIPTION
Followup on https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/411#discussion_r708516996

* Inlined well-known constants (HTTP, HTTPS, TCP, TLS)
* Added explicit load balancer type checks for both HTTP and HTTPS listeners
* Moved target group protocol and health check protocol selection close to target group construction