### PR TITLE
Do not attach nonexistent target groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ Dockerfile.upstream
 /.GOPATH
 /bin
 profile.cov
+
+.idea/

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -543,7 +543,7 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 	for _, asg := range a.TargetedAutoScalingGroups {
 		// This call is idempotent and safe to execute every time
 		if err := updateTargetGroupsForAutoScalingGroup(a.autoscaling, a.elbv2, targetGroupARNs, asg.name, ownerTags); err != nil {
-			log.Errorf("failed to update target groups for autoscaling group %q: %v", asg.name, err)
+			log.Errorf("Failed to update target groups for autoscaling group %q: %v", asg.name, err)
 		}
 	}
 
@@ -552,7 +552,7 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 	for _, asg := range nonTargetedASGs {
 		// This call is idempotent and safe to execute every time
 		if err := updateTargetGroupsForAutoScalingGroup(a.autoscaling, a.elbv2, nil, asg.name, ownerTags); err != nil {
-			log.Errorf("failed to update target groups for non-targeted autoscaling group %q: %v", asg.name, err)
+			log.Errorf("Failed to update target groups for non-targeted autoscaling group %q: %v", asg.name, err)
 		}
 	}
 
@@ -560,13 +560,13 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 	if len(runningSingleInstances) != 0 {
 		// This call is idempotent too
 		if err := registerTargetsOnTargetGroups(a.elbv2, targetGroupARNs, runningSingleInstances); err != nil {
-			log.Errorf("failed to register instances %q in target groups: %v", runningSingleInstances, err)
+			log.Errorf("Failed to register instances %q in target groups: %v", runningSingleInstances, err)
 		}
 	}
 	if len(a.obsoleteInstances) != 0 {
 		// Deregister instances from target groups and clean up list of obsolete instances
 		if err := deregisterTargetsOnTargetGroups(a.elbv2, targetGroupARNs, a.obsoleteInstances); err != nil {
-			log.Errorf("failed to deregister instances %q in target groups: %v", a.obsoleteInstances, err)
+			log.Errorf("Failed to deregister instances %q in target groups: %v", a.obsoleteInstances, err)
 		} else {
 			a.obsoleteInstances = make([]string, 0)
 		}
@@ -898,7 +898,7 @@ func (a *Adapter) parseFilters(clusterId string) []*ec2.Filter {
 		for i, term := range terms {
 			parts := strings.Split(term, "=")
 			if len(parts) != 2 {
-				log.Errorf("failed parsing %s, falling back to default", a.customFilter)
+				log.Errorf("Failed parsing %s, falling back to default", a.customFilter)
 				return generateDefaultFilters(clusterId)
 			}
 			filters[i] = &ec2.Filter{
@@ -935,7 +935,7 @@ func (a *Adapter) parseAutoscaleFilterTags(clusterId string) map[string][]string
 		for _, term := range terms {
 			parts := strings.Split(term, "=")
 			if len(parts) != 2 {
-				log.Errorf("failed parsing %s, falling back to default", a.customFilter)
+				log.Errorf("Failed parsing %s, falling back to default", a.customFilter)
 				return generateDefaultAutoscaleFilterTags(clusterId)
 			}
 			if parts[0] == "tag-key" {

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -543,7 +543,7 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 	for _, asg := range a.TargetedAutoScalingGroups {
 		// This call is idempotent and safe to execute every time
 		if err := updateTargetGroupsForAutoScalingGroup(a.autoscaling, a.elbv2, targetGroupARNs, asg.name, ownerTags); err != nil {
-			log.Errorf("UpdateTargetGroupsAndAutoScalingGroups() failed to attach target groups to ASG '%s': %v", asg.name, err)
+			log.Errorf("failed to update target groups for autoscaling group %q: %v", asg.name, err)
 		}
 	}
 
@@ -552,7 +552,7 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 	for _, asg := range nonTargetedASGs {
 		// This call is idempotent and safe to execute every time
 		if err := updateTargetGroupsForAutoScalingGroup(a.autoscaling, a.elbv2, nil, asg.name, ownerTags); err != nil {
-			log.Errorf("UpdateTargetGroupsAndAutoScalingGroups() failed to attach target groups to ASG '%s': %v", asg.name, err)
+			log.Errorf("failed to update target groups for non-targeted autoscaling group %q: %v", asg.name, err)
 		}
 	}
 
@@ -560,13 +560,13 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack) {
 	if len(runningSingleInstances) != 0 {
 		// This call is idempotent too
 		if err := registerTargetsOnTargetGroups(a.elbv2, targetGroupARNs, runningSingleInstances); err != nil {
-			log.Errorf("UpdateTargetGroupsAndAutoScalingGroups() failed to register instances %q in target groups: %v", runningSingleInstances, err)
+			log.Errorf("failed to register instances %q in target groups: %v", runningSingleInstances, err)
 		}
 	}
 	if len(a.obsoleteInstances) != 0 {
 		// Deregister instances from target groups and clean up list of obsolete instances
 		if err := deregisterTargetsOnTargetGroups(a.elbv2, targetGroupARNs, a.obsoleteInstances); err != nil {
-			log.Errorf("UpdateTargetGroupsAndAutoScalingGroups() failed to deregister instances %q in target groups: %v", a.obsoleteInstances, err)
+			log.Errorf("failed to deregister instances %q in target groups: %v", a.obsoleteInstances, err)
 		} else {
 			a.obsoleteInstances = make([]string, 0)
 		}
@@ -721,10 +721,9 @@ func (a *Adapter) GetStack(stackID string) (*Stack, error) {
 func (a *Adapter) DeleteStack(stack *Stack) error {
 	for _, asg := range a.TargetedAutoScalingGroups {
 		if err := detachTargetGroupsFromAutoScalingGroup(a.autoscaling, stack.TargetGroupARNs, asg.name); err != nil {
-			return fmt.Errorf("DeleteStack failed to detach: %v", err)
+			return fmt.Errorf("failed to detach target groups from autoscaling group %q: %w", asg.name, err)
 		}
 	}
-
 	return deleteStack(a.cloudformation, stack.Name)
 }
 

--- a/aws/asg.go
+++ b/aws/asg.go
@@ -219,7 +219,7 @@ func updateTargetGroupsForAutoScalingGroup(svc autoscalingiface.AutoScalingAPI, 
 			attachARNs = append(attachARNs, tgARN)
 		} else {
 			// TODO: it is better to validate stack's target groups earlier to identify owning stack
-			log.Errorf("target group %q does not exist, will not attach", tgARN)
+			log.Errorf("Target group %q does not exist, will not attach", tgARN)
 		}
 	}
 

--- a/aws/asgmock_test.go
+++ b/aws/asgmock_test.go
@@ -1,10 +1,16 @@
 package aws
 
 import (
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 )
+
+type autoscalingMockInputs struct {
+	attachLoadBalancerTargetGroups func(*testing.T, *autoscaling.AttachLoadBalancerTargetGroupsInput)
+}
 
 type autoscalingMockOutputs struct {
 	describeAutoScalingGroups        *apiResponse
@@ -16,6 +22,8 @@ type autoscalingMockOutputs struct {
 type mockAutoScalingClient struct {
 	autoscalingiface.AutoScalingAPI
 	outputs autoscalingMockOutputs
+	inputs  autoscalingMockInputs
+	t       *testing.T
 }
 
 func (m *mockAutoScalingClient) DescribeAutoScalingGroups(*autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
@@ -39,7 +47,10 @@ func (m *mockAutoScalingClient) DescribeLoadBalancerTargetGroups(*autoscaling.De
 	return nil, m.outputs.describeLoadBalancerTargetGroups.err
 }
 
-func (m *mockAutoScalingClient) AttachLoadBalancerTargetGroups(*autoscaling.AttachLoadBalancerTargetGroupsInput) (*autoscaling.AttachLoadBalancerTargetGroupsOutput, error) {
+func (m *mockAutoScalingClient) AttachLoadBalancerTargetGroups(input *autoscaling.AttachLoadBalancerTargetGroupsInput) (*autoscaling.AttachLoadBalancerTargetGroupsOutput, error) {
+	if m.inputs.attachLoadBalancerTargetGroups != nil {
+		m.inputs.attachLoadBalancerTargetGroups(m.t, input)
+	}
 	return nil, m.outputs.attachLoadBalancerTargetGroups.err
 }
 

--- a/worker.go
+++ b/worker.go
@@ -577,7 +577,7 @@ func updateIngress(kubeAdapter *kubernetes.Adapter, lb *loadBalancer) {
 func deleteStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 	stackName := lb.stack.Name
 	if err := awsAdapter.DeleteStack(lb.stack); err != nil {
-		log.Errorf("deleteStack failed to delete stack %q: %v", stackName, err)
+		log.Errorf("failed to delete stack %q: %v", stackName, err)
 	} else {
 		log.Infof("deleted orphaned stack %q", stackName)
 	}

--- a/worker.go
+++ b/worker.go
@@ -260,7 +260,7 @@ func doWork(
 ) error {
 	defer func() error {
 		if r := recover(); r != nil {
-			log.Errorln("shit has hit the fan:", errors.Wrap(r.(error), "panic caused by"))
+			log.Errorln("Shit has hit the fan:", errors.Wrap(r.(error), "panic caused by"))
 			debug.PrintStack()
 			return r.(error)
 		}
@@ -500,7 +500,7 @@ func createStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 		certificates = append(certificates, cert)
 	}
 
-	log.Infof("creating stack for certificates %q / ingress %q", certificates, lb.ingresses)
+	log.Infof("Creating stack for certificates %q / ingress %q", certificates, lb.ingresses)
 
 	stackId, err := awsAdapter.CreateStack(certificates, lb.scheme, lb.securityGroup, lb.Owner(), lb.sslPolicy, lb.ipAddressType, lb.wafWebACLID, lb.cwAlarms, lb.loadBalancerType, lb.http2)
 	if err != nil {
@@ -510,24 +510,24 @@ func createStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 				return
 			}
 		}
-		log.Errorf("createStack(%q) failed: %v", certificates, err)
+		log.Errorf("CreateStack(%q) failed: %v", certificates, err)
 	} else {
-		log.Infof("stack %q for certificates %q created", stackId, certificates)
+		log.Infof("Stack %q for certificates %q created", stackId, certificates)
 	}
 }
 
 func updateStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 	certificates := lb.CertificateARNs()
 
-	log.Infof("updating %q stack for %d certificates / %d ingresses", lb.scheme, len(certificates), len(lb.ingresses))
+	log.Infof("Updating %q stack for %d certificates / %d ingresses", lb.scheme, len(certificates), len(lb.ingresses))
 
 	stackId, err := awsAdapter.UpdateStack(lb.stack.Name, certificates, lb.scheme, lb.securityGroup, lb.Owner(), lb.sslPolicy, lb.ipAddressType, lb.wafWebACLID, lb.cwAlarms, lb.loadBalancerType, lb.http2)
 	if isNoUpdatesToBePerformedError(err) {
-		log.Debugf("stack(%q) is already up to date", certificates)
+		log.Debugf("Stack(%q) is already up to date", certificates)
 	} else if err != nil {
-		log.Errorf("updateStack(%q) failed: %v", certificates, err)
+		log.Errorf("UpdateStack(%q) failed: %v", certificates, err)
 	} else {
-		log.Infof("stack %q for certificate %q updated", stackId, certificates)
+		log.Infof("Stack %q for certificate %q updated", stackId, certificates)
 	}
 }
 
@@ -568,7 +568,7 @@ func updateIngress(kubeAdapter *kubernetes.Adapter, lb *loadBalancer) {
 					log.Errorf("Failed to update ingress: %v", err)
 				}
 			} else {
-				log.Infof("updated ingress %v with DNS name %q", ing, dnsName)
+				log.Infof("Updated ingress %v with DNS name %q", ing, dnsName)
 			}
 		}
 	}
@@ -577,9 +577,9 @@ func updateIngress(kubeAdapter *kubernetes.Adapter, lb *loadBalancer) {
 func deleteStack(awsAdapter *aws.Adapter, lb *loadBalancer) {
 	stackName := lb.stack.Name
 	if err := awsAdapter.DeleteStack(lb.stack); err != nil {
-		log.Errorf("failed to delete stack %q: %v", stackName, err)
+		log.Errorf("Failed to delete stack %q: %v", stackName, err)
 	} else {
-		log.Infof("deleted orphaned stack %q", stackName)
+		log.Infof("Deleted orphaned stack %q", stackName)
 	}
 }
 
@@ -620,7 +620,7 @@ func getCloudWatchAlarmsFromConfigMap(configMap *kubernetes.ConfigMap) aws.Cloud
 
 		list, err := aws.NewCloudWatchAlarmListFromYAML(data)
 		if err != nil {
-			log.Warnf("ignoring cloudwatch alarm configuration from config map key %q due to error: %v", key, err)
+			log.Warnf("Ignoring cloudwatch alarm configuration from config map key %q due to error: %v", key, err)
 			continue
 		}
 


### PR DESCRIPTION
When controller attempts to attach a batch of target groups that
contains nonexistent target group (could be deleted manually by mistake)
to the autoscaling group the attempt fails to pass validation which
prevents attachment of the other valid target groups from the batch.

Also:
* Improves error log messages
* Adds processChunked helper function
* Adds describeTargetGroups
* Fixes `detachARNs`/`validARNs` slices' capacity

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>