### PR TITLE
adding config option for ALB & NLB healthy threshold count

### DIFF
--- a/aws/adapter_test.go
+++ b/aws/adapter_test.go
@@ -927,3 +927,23 @@ func TestWithTargetHTTPS(t *testing.T) {
 		require.Equal(t, true, b.targetHTTPS)
 	})
 }
+
+func TestWithxlbHealthyThresholdCount(t *testing.T) {
+	t.Run("WithAlbHealthyThresholdCount sets the albHealthyThresholdCount property", func(t *testing.T) {
+		a := Adapter{}
+		b := a.WithAlbHealthyThresholdCount(2)
+		require.Equal(t, uint(2), b.albHealthyThresholdCount)
+	})
+
+	t.Run("WithAlbUnhealthyThresholdCount sets the albUnhealthyThresholdCount property", func(t *testing.T) {
+		a := Adapter{}
+		b := a.WithAlbUnhealthyThresholdCount(3)
+		require.Equal(t, uint(3), b.albUnhealthyThresholdCount)
+	})
+
+	t.Run("WithNlbHealthyThresholdCount sets the nlbHealthyThresholdCount property", func(t *testing.T) {
+		a := Adapter{}
+		b := a.WithNlbHealthyThresholdCount(4)
+		require.Equal(t, uint(4), b.nlbHealthyThresholdCount)
+	})
+}

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -137,6 +137,9 @@ type stackSpec struct {
 	clusterID                         string
 	vpcID                             string
 	healthCheck                       *healthCheck
+	albHealthyThresholdCount          uint
+	albUnhealthyThresholdCount        uint
+	nlbHealthyThresholdCount          uint
 	targetPort                        uint
 	targetHTTPS                       bool
 	httpDisabled                      bool

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -446,9 +446,12 @@ func generateDenyInternalTrafficRule(listenerName string, rulePriority int64, in
 func newTargetGroup(spec *stackSpec, targetPortParameter string) *cloudformation.ElasticLoadBalancingV2TargetGroup {
 	protocol := "HTTP"
 	healthCheckProtocol := "HTTP"
+	healthyThresholdCount, unhealthyThresholdCount := spec.albHealthyThresholdCount, spec.albUnhealthyThresholdCount
 	if spec.loadbalancerType == LoadBalancerTypeNetwork {
 		protocol = "TCP"
 		healthCheckProtocol = "HTTP"
+		// For NLBs the healthy and unhealthy threshold count value must be equal
+		healthyThresholdCount, unhealthyThresholdCount = spec.nlbHealthyThresholdCount, spec.nlbHealthyThresholdCount
 	} else if spec.targetHTTPS {
 		protocol = "HTTPS"
 		healthCheckProtocol = "HTTPS"
@@ -465,6 +468,8 @@ func newTargetGroup(spec *stackSpec, targetPortParameter string) *cloudformation
 		HealthCheckPath:            cloudformation.Ref(parameterTargetGroupHealthCheckPathParameter).String(),
 		HealthCheckPort:            cloudformation.Ref(parameterTargetGroupHealthCheckPortParameter).String(),
 		HealthCheckProtocol:        cloudformation.String(healthCheckProtocol),
+		HealthyThresholdCount:      cloudformation.Integer(int64(healthyThresholdCount)),
+		UnhealthyThresholdCount:    cloudformation.Integer(int64(unhealthyThresholdCount)),
 		Port:                       cloudformation.Ref(targetPortParameter).Integer(),
 		Protocol:                   cloudformation.String(protocol),
 		VPCID:                      cloudformation.Ref(parameterTargetGroupVPCIDParameter).String(),


### PR DESCRIPTION
Healthy threshold: The number of consecutive health checks successes required before considering an unhealthy target healthy

This configuration is required since the default of "5" time the interval, which is minimum of 6s, sums up to 30s that is too long delay in our configurations.

Signed-off-by: Samuel Lang <gh@lang-sam.de>