### PR TITLE
clean up invalid target groups

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -594,10 +594,6 @@ func (a *Adapter) UpdateTargetGroupsAndAutoScalingGroups(stacks []*Stack, proble
 
 	// remove the IP TGs from the list keeping all other TGs including problematic #127 and nonexistent #436
 	targetGroupARNs := difference(allTargetGroupARNs, targetTypesARNs[elbv2.TargetTypeEnumIp])
-	// don't do anything if there are no target groups
-	if len(targetGroupARNs) == 0 {
-		return
-	}
 
 	ownerTags := map[string]string{
 		clusterIDTagPrefix + a.ClusterID(): resourceLifecycleOwned,


### PR DESCRIPTION
fixes: #475

Given that there is only one TG and it is of type IP created by the stack, we are not callling `updateTargetGroupsForAutoScalingGroup` -> `detachTargetGroupsFromAutoScalingGroup`

This possible solution is to move this guard inside `updateTargetGroupsForAutoScalingGroup` - see https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/475#issuecomment-1033827245

However, the  guard introduced in #141 is practically present now inside `updateTargetGroupsForAutoScalingGroup`  introduced by #436 and therefore we can simply remove it.

Tested in lab clusters.

Signed-off-by: Samuel Lang <gh@lang-sam.de>