### PR TITLE
Only disable 'excotic' features on NotFound/NoAccess errors

### DIFF
--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -317,10 +317,11 @@ func (a *Adapter) ListResources() ([]*Ingress, error) {
 	if a.routeGroupSupport {
 		rgs, err = a.ListRoutegroups()
 		if err != nil {
-			a.routeGroupSupport = false
-			log.Warnf("Disabling RouteGroup support because listing RouteGroups failed: %v, to get more information https://opensource.zalando.com/skipper/kubernetes/routegroups/#routegroups", err)
-			// Generic error, RouteGroup CRD exists and we have permission to access
-			if err != ErrResourceNotFound && err != ErrNoPermissionToAccessResource {
+			if errors.Is(err, ErrResourceNotFound) || errors.Is(err, ErrNoPermissionToAccessResource) {
+				a.routeGroupSupport = false
+				log.Warnf("Disabling RouteGroup support because listing RouteGroups failed: %v, to get more information https://opensource.zalando.com/skipper/kubernetes/routegroups/#routegroups", err)
+			} else {
+				// Generic error, RouteGroup CRD exists and we have permission to access
 				return nil, err
 			}
 		}
@@ -330,10 +331,11 @@ func (a *Adapter) ListResources() ([]*Ingress, error) {
 	if a.fabricSupport {
 		fgs, err = a.ListFabricgateways()
 		if err != nil {
-			a.fabricSupport = false
-			log.Warnf("Disabling FabricGateway support because listing FabricGateways failed: %v, to get more information https://opensource.zalando.com/skipper/kubernetes/fabric/#fabricgateways", err)
-			// Generic error, FabricGateway CRD exists and we have permission to access
-			if err != ErrResourceNotFound && err != ErrNoPermissionToAccessResource {
+			if errors.Is(err, ErrResourceNotFound) || errors.Is(err, ErrNoPermissionToAccessResource) {
+				a.fabricSupport = false
+				log.Warnf("Disabling FabricGateway support because listing FabricGateways failed: %v, to get more information https://opensource.zalando.com/skipper/kubernetes/fabric/#fabricgateways", err)
+			} else {
+				// Generic error, FabricGateway CRD exists and we have permission to access
 				return nil, err
 			}
 		}


### PR DESCRIPTION
In case we got any error listing `RouteGroups` or `FabricGateways` we would disable support assuming the resource is not available in the cluster.

This means that the feature can get disabled e.g. if the api-server is unavailable which was not the intention.

Fix the logic to only disable the features on specific errors: `NotFound` (404) and `NoAccess` (403).