### PR TITLE
worker: check cloudformation stack status

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -282,6 +282,12 @@ func doWork(
 		return problems.Add("failed to list managed stacks: %w", err)
 	}
 
+	for _, stack := range stacks {
+		if err := stack.Err(); err != nil {
+			problems.Add("stack %s error: %w", stack.Name, err)
+		}
+	}
+
 	err = awsAdapter.UpdateAutoScalingGroupsAndInstances()
 	if err != nil {
 		return problems.Add("failed to get instances from EC2: %w", err)


### PR DESCRIPTION
Stack update may fail due to external changes, e.g. due to removal of
a referenced security group.

This change reports certain stack statuses as problems which prevents
`last_sync_timestamp_seconds` metric update that could be
used to monitor stack update failures.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>