### PR TITLE
Build multi-arch container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM registry.opensource.zalan.do/library/alpine-3.12:latest
+ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3.13:latest
+FROM ${BASE_IMAGE}
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 
-ADD build/linux/kube-ingress-aws-controller /
+ARG TARGETARCH
+
+ADD build/linux/${TARGETARCH}/kube-ingress-aws-controller /
 
 ENTRYPOINT ["/kube-ingress-aws-controller"]

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ fmt:
 ## build.local: builds a local binary in build directory
 build.local: build/$(BINARY)
 
-## build.local: builds a binary for linux/amd64 in build directory
+## build.linux: builds a binary for linux/amd64 in build directory
 build.linux: build/linux/$(BINARY)
 
-## build.osx: builds a binary for osx/amd64 in build directory
-build.osx: build/osx/$(BINARY)
+build.linux.amd64: build/linux/amd64/$(BINARY)
+build.linux.arm64: build/linux/arm64/$(BINARY)
 
 build/$(BINARY): $(SOURCES)
 	CGO_ENABLED=0 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
@@ -45,12 +45,15 @@ build/$(BINARY): $(SOURCES)
 build/linux/$(BINARY): $(SOURCES)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/linux/$(BINARY) -ldflags "$(LDFLAGS)" .
 
-build/osx/$(BINARY): $(SOURCES)
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/osx/$(BINARY) -ldflags "$(LDFLAGS)" .
+build/linux/amd64/$(BINARY): go.mod $(SOURCES)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/linux/amd64/$(BINARY) -ldflags "$(LDFLAGS)" .
+
+build/linux/arm64/$(BINARY): go.mod $(SOURCES)
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/linux/arm64/$(BINARY) -ldflags "$(LDFLAGS)" .
 
 ## build.docker: builds docker image
 build.docker: build.linux
-	docker build --rm -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) .
+	docker build --rm -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) --build-arg TARGETARCH= .
 
 ## build.push: pushes docker image to registry
 build.push: build.docker

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -19,14 +19,20 @@ pipeline:
       git diff --exit-code || exit 1
   - desc: Push docker image
     cmd: |
-      if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
-        IMAGE=registry-write.opensource.zalan.do/teapot/kube-ingress-aws-controller
-        VERSION=$(git describe --tags --always --dirty)
-      else
+      if [[ $CDP_TARGET_BRANCH != master && $CDP_PULL_REQUEST_NUMBER ]]; then
         IMAGE=registry-write.opensource.zalan.do/teapot/kube-ingress-aws-controller-test
         VERSION=$CDP_BUILD_VERSION
         IMAGE=$IMAGE VERSION=$VERSION make build.push
+
+        # multi-arch image
+        IMAGE=container-registry-test.zalando.net/teapot/kube-ingress-aws-controller
+
+        make build.linux.amd64 build.linux.arm64
+
+        docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
+        docker buildx build --rm --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3.13:latest -t "${IMAGE}:${CDP_BUILD_VERSION}" --platform linux/amd64,linux/arm64 --push .
       fi
+
 - id: buildprod
   when:
     branch: master
@@ -55,6 +61,14 @@ pipeline:
       IMAGE=$IMAGE VERSION=$VERSION make build.docker
       git diff --stat --exit-code
       IMAGE=$IMAGE VERSION=$VERSION make build.push
+
+      # multi-arch image (Zalando private)
+      make build.linux.amd64 build.linux.arm64
+      IMAGE=container-registry-test.zalando.net/teapot/kube-ingress-aws-controller
+      docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
+      docker buildx build --rm --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3.13:latest -t "${IMAGE}:${VERSION}" --platform linux/amd64,linux/arm64 --push .
+      cdp-promote-image "${IMAGE}:${VERSION}"
+
       echo "create release page"
       tf=$(mktemp)
       echo -e "### Changes\n" >$tf


### PR DESCRIPTION
Build multi-arch container image along with the single-arch open source image.

Additionally drop the OSX target in Makefile as `make build.local` does the right thing.