### PR TITLE
Used cdp-runtime/golang for prod build

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -36,7 +36,9 @@ pipeline:
 - id: buildprod
   when:
     branch: master
-  overlay: ci/golang
+  vm_config:
+    type: linux
+    image: "cdp-runtime/go"
   type: script
   env:
     GOFLAGS: "-mod=readonly"


### PR DESCRIPTION
Multi-arch build (#517) for the prod-build step didn't work because it was still using the legacy CDP overlay. Change to cdp-runtime and get latest Go version as well.