### PR TITLE
Allow changing settings on an owned LB

### DIFF
--- a/worker_test.go
+++ b/worker_test.go
@@ -169,12 +169,31 @@ func TestAddIngress(tt *testing.T) {
 			},
 			added: false,
 		},
+		{
+			name: "Adding/changing WAF, SG or TLS settings on non-shared LB should work",
+			loadBalancer: &loadBalancer{
+				ingresses: make(map[string][]*kubernetes.Ingress),
+				stack: &aws.Stack{
+					OwnerIngress: "foo/bar",
+				},
+				sslPolicy: "ELBSecurityPolicy-2016-08",
+			},
+			ingress: &kubernetes.Ingress{
+				Name:          "bar",
+				Namespace:     "foo",
+				WAFWebACLID:   "WAFZXX",
+				SecurityGroup: "bar",
+				SSLPolicy:     "ELBSecurityPolicy-FS-2018-06",
+				Shared:        false,
+			},
+			added: true,
+		},
 	} {
 		tt.Run(test.name, func(t *testing.T) {
 			assert.Equal(
 				t,
-				test.loadBalancer.addIngress(test.certificateARNs, test.ingress, test.maxCerts),
 				test.added,
+				test.loadBalancer.addIngress(test.certificateARNs, test.ingress, test.maxCerts),
 			)
 		})
 	}


### PR DESCRIPTION
By default adding a WAF ACL ID or a security group etc. to an ingress/routegroup would require the creation of a new load balancer. This makes sense for the cases where the load balancer is shared by multiple ingresses/routegroups but for those load balancers only owned by a single resource (via `zalando.org/aws-load-balancer-shared=false`) it doesn't really make sense to create a new load balancer when the setting is just adding/changing a security group, WAF ACL or the TLS settings which can be done in-place on a running LB.

This PR handles the above case so we reduce the situations where a new load balancer needs to be created.