### PR TITLE
Update golanci-lint and address suggestions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,10 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.18'
+        go-version: '^1.19'
     - run: go version
     - run: go install github.com/mattn/goveralls@latest
-    - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_RELEASE}
-      env:
-        GOLANGCI_RELEASE: v1.45.2
+    - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     - run: make test
     - run: make lint
     - run: goveralls -coverprofile=profile.cov -service=github

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,12 @@ run:
 linters:
   disable-all: true
   enable:
-    - staticcheck
-    - govet
-    - ineffassign
-    - goimports
+  - deadcode
+  - errcheck
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - typecheck
+  - unused
+  - varcheck

--- a/aws/acm.go
+++ b/aws/acm.go
@@ -42,9 +42,7 @@ func getACMCertificateSummaries(api acmiface.ACMAPI) ([]*acm.CertificateSummary,
 	}
 	acmSummaries := make([]*acm.CertificateSummary, 0)
 	err := api.ListCertificatesPages(params, func(page *acm.ListCertificatesOutput, lastPage bool) bool {
-		for _, cert := range page.CertificateSummaryList {
-			acmSummaries = append(acmSummaries, cert)
-		}
+		acmSummaries = append(acmSummaries, page.CertificateSummaryList...)
 		return true
 	})
 	return acmSummaries, err

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -92,8 +92,6 @@ type manifest struct {
 	vpcID         string
 }
 
-type configProviderFunc func() client.ConfigProvider
-
 const (
 	DefaultHealthCheckPath            = "/kube-system/healthz"
 	DefaultHealthCheckPort            = 9999

--- a/aws/asg.go
+++ b/aws/asg.go
@@ -109,10 +109,7 @@ func testFilterTags(filterTags map[string][]string, asgTags map[string]string) b
 			return false
 		}
 	}
-	if len(filterTags) == len(matches) {
-		return true
-	}
-	return false
+	return len(filterTags) == len(matches)
 }
 
 func getOwnedAndTargetedAutoScalingGroups(service autoscalingiface.AutoScalingAPI, filterTags map[string][]string, ownedTags map[string]string) (map[string]*autoScalingGroupDetails, map[string]*autoScalingGroupDetails, error) {

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -143,7 +143,6 @@ const (
 	parameterTargetGroupTargetPortParameter          = "TargetGroupTargetPortParameter"
 	parameterTargetGroupHTTPTargetPortParameter      = "TargetGroupHTTPTargetPortParameter"
 	parameterTargetGroupVPCIDParameter               = "TargetGroupVPCIDParameter"
-	parameterListenerCertificatesParameter           = "ListenerCertificatesParameter"
 	parameterListenerSslPolicyParameter              = "ListenerSslPolicyParameter"
 	parameterIpAddressTypeParameter                  = "IpAddressType"
 	parameterLoadBalancerTypeParameter               = "Type"
@@ -169,7 +168,6 @@ type stackSpec struct {
 	httpDisabled                      bool
 	httpTargetPort                    uint
 	timeoutInMinutes                  uint
-	customTemplate                    string
 	stackTerminationProtection        bool
 	idleConnectionTimeoutSeconds      uint
 	deregistrationDelayTimeoutSeconds uint

--- a/aws/iam.go
+++ b/aws/iam.go
@@ -40,9 +40,7 @@ func getIAMServerCertificateMetadata(api iamiface.IAMAPI) ([]*iam.ServerCertific
 	}
 	certList := make([]*iam.ServerCertificateMetadata, 0)
 	err := api.ListServerCertificatesPages(params, func(p *iam.ListServerCertificatesOutput, lastPage bool) bool {
-		for _, cert := range p.ServerCertificateMetadataList {
-			certList = append(certList, cert)
-		}
+		certList = append(certList, p.ServerCertificateMetadataList...)
 		return true
 	})
 	return certList, err

--- a/aws/mocks_test.go
+++ b/aws/mocks_test.go
@@ -9,8 +9,6 @@ type apiResponse struct {
 
 type tags map[string]string
 
-type awsTags map[string]tags
-
 var errDummy = errors.New("fail")
 
 func R(r interface{}, e error) *apiResponse {

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientGet(t *testing.T) {
@@ -35,7 +37,8 @@ func TestClientGet(t *testing.T) {
 					w.WriteHeader(http.StatusBadRequest)
 				}
 				w.WriteHeader(test.responseCode)
-				io.WriteString(w, test.responseBody)
+				_, err := io.WriteString(w, test.responseBody)
+				require.NoError(t, err)
 			}
 
 			server := httptest.NewServer(http.HandlerFunc(handler))
@@ -101,7 +104,8 @@ func TestClientPatch(t *testing.T) {
 					t.Errorf("unexpected request payload. wanted %v, got %v\n", test.payload, b)
 				}
 				w.WriteHeader(test.responseCode)
-				io.WriteString(w, test.responseBody)
+				_, err = io.WriteString(w, test.responseBody)
+				require.NoError(t, err)
 			}
 
 			server := httptest.NewServer(http.HandlerFunc(handler))
@@ -146,7 +150,8 @@ func TestTLS(t *testing.T) {
 			t.Errorf(`unexpected request body. wanted "bar" but got %q`, string(buf))
 		}
 		w.WriteHeader(http.StatusOK)
-		io.Copy(w, r.Body)
+		_, err = io.Copy(w, r.Body)
+		require.NoError(t, err)
 	}
 	cert, err := tls.LoadX509KeyPair("testdata/cert.pem", "testdata/key.pem")
 	if err != nil {

--- a/kubernetes/config_map_test.go
+++ b/kubernetes/config_map_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetConfigMap(t *testing.T) {
@@ -15,7 +17,8 @@ func TestGetConfigMap(t *testing.T) {
 		f, _ := os.Open("testdata/fixture02.json")
 		defer f.Close()
 		rw.WriteHeader(http.StatusOK)
-		io.Copy(rw, f)
+		_, err := io.Copy(rw, f)
+		require.NoError(t, err)
 	}))
 	defer testServer.Close()
 

--- a/kubernetes/ingress_test.go
+++ b/kubernetes/ingress_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListIngresses(t *testing.T) {
@@ -18,7 +19,8 @@ func TestListIngresses(t *testing.T) {
 		f, _ := os.Open("testdata/fixture01.json")
 		defer f.Close()
 		rw.WriteHeader(http.StatusOK)
-		io.Copy(rw, f)
+		_, err := io.Copy(rw, f)
+		require.NoError(t, err)
 	}))
 	defer testServer.Close()
 	kubeClient, _ := newSimpleClient(&Config{BaseURL: testServer.URL}, false)
@@ -46,7 +48,8 @@ func TestListIngressesV1(t *testing.T) {
 		f, _ := os.Open("testdata/fixture03.json")
 		defer f.Close()
 		rw.WriteHeader(http.StatusOK)
-		io.Copy(rw, f)
+		_, err := io.Copy(rw, f)
+		require.NoError(t, err)
 	}))
 	defer testServer.Close()
 	kubeClient, _ := newSimpleClient(&Config{BaseURL: testServer.URL}, false)

--- a/kubernetes/routegroup_test.go
+++ b/kubernetes/routegroup_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestListRoutegroups(t *testing.T) {
@@ -16,7 +18,9 @@ func TestListRoutegroups(t *testing.T) {
 		f, _ := os.Open("testdata/fixture01_rg.json")
 		defer f.Close()
 		rw.WriteHeader(http.StatusOK)
-		io.Copy(rw, f)
+		_, err := io.Copy(rw, f)
+		require.NoError(t, err)
+
 	}))
 	defer testServer.Close()
 	kubeClient, _ := newSimpleClient(&Config{BaseURL: testServer.URL}, false)

--- a/worker.go
+++ b/worker.go
@@ -46,8 +46,7 @@ const (
 )
 
 const (
-	maxTargetGroupSupported = 1000
-	cniEventRateLimit       = 5 * time.Second
+	cniEventRateLimit = 5 * time.Second
 )
 
 func (l *loadBalancer) Status() int {
@@ -671,7 +670,13 @@ func cniEventHandler(ctx context.Context, targetCNIcfg *aws.TargetCNIconfig,
 	defer rateLimiter.Stop()
 
 	endpointCh := make(chan []string, 10)
-	go informer(ctx, endpointCh)
+	go func() {
+		err := informer(ctx, endpointCh)
+		if err != nil {
+			log.Errorf("Informer failed: %v", err)
+			return
+		}
+	}()
 
 	var cniTargetGroupARNs, endpoints []string
 	for {


### PR DESCRIPTION
This updates golangci-lint to always use the latest version on github-actions. It also ~drops the `.golangci.yml` config and uses the default settings which adds new and previously suppressed linters~ updates the `.golangci.yml` to have the list of current default linters from golangci-lint.
Lastly it addresses all the lint errors identified.