### PR TITLE
remove golint because project is archived

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,10 @@
 run:
   concurrency: 4
 
-linters-settings:
-  golint:
-      min-confidence: 0.9
-
 linters:
   disable-all: true
   enable:
     - staticcheck
     - govet
     - ineffassign
-    - golint
     - goimports


### PR DESCRIPTION
 remove golint because project is archived deprecated for a while and staticcheck covers IMO everything we need

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>