### PR TITLE
Use full path for token file

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -155,7 +155,7 @@ func (c *simpleClient) createRequest(method, resource string, body io.Reader) (*
 		req.Header.Set("User-Agent", c.cfg.UserAgent)
 	}
 	if c.cfg.TokenProvider != nil {
-		token, ok := c.cfg.TokenProvider.GetSecret(serviceAccountTokenKey)
+		token, ok := c.cfg.TokenProvider.GetSecret(serviceAccountDir + serviceAccountTokenKey)
 		if !ok {
 			return nil, fmt.Errorf("secret not found: %v", serviceAccountTokenKey)
 		}


### PR DESCRIPTION
Follow up to #551 which was missing the service account token file path when getting the token from the secretsReader.