### PR TITLE
aws: fix test name

### DIFF
--- a/aws/adapter_test.go
+++ b/aws/adapter_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/zalando-incubator/kube-ingress-aws-controller/aws/fake"
 )
 
-func TesGenerateDefaultFilters(tt *testing.T) {
+func TestGenerateDefaultFilters(tt *testing.T) {
 	for _, test := range []struct {
 		name      string
 		clusterId string


### PR DESCRIPTION
Found via `deadcode -test ./...`

See https://pkg.go.dev/golang.org/x/tools/internal/cmd/deadcode