### PR TITLE
Add option to filter certificates by tag before adding it to LB

### DIFF
--- a/aws/acm.go
+++ b/aws/acm.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"crypto/x509"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
@@ -10,16 +11,17 @@ import (
 )
 
 type acmCertificateProvider struct {
-	api acmiface.ACMAPI
+	api       acmiface.ACMAPI
+	filterTag string
 }
 
-func newACMCertProvider(api acmiface.ACMAPI) certs.CertificatesProvider {
-	return &acmCertificateProvider{api: api}
+func newACMCertProvider(api acmiface.ACMAPI, certFilterTag string) certs.CertificatesProvider {
+	return &acmCertificateProvider{api: api, filterTag: certFilterTag}
 }
 
 // GetCertificates returns a list of AWS ACM certificates
 func (p *acmCertificateProvider) GetCertificates() ([]*certs.CertificateSummary, error) {
-	acmSummaries, err := getACMCertificateSummaries(p.api)
+	acmSummaries, err := getACMCertificateSummaries(p.api, p.filterTag)
 	if err != nil {
 		return nil, err
 	}
@@ -34,18 +36,45 @@ func (p *acmCertificateProvider) GetCertificates() ([]*certs.CertificateSummary,
 	return result, nil
 }
 
-func getACMCertificateSummaries(api acmiface.ACMAPI) ([]*acm.CertificateSummary, error) {
+func getACMCertificateSummaries(api acmiface.ACMAPI, filterTag string) ([]*acm.CertificateSummary, error) {
 	params := &acm.ListCertificatesInput{
 		CertificateStatuses: []*string{
 			aws.String(acm.CertificateStatusIssued),
 		},
 	}
 	acmSummaries := make([]*acm.CertificateSummary, 0)
+
 	err := api.ListCertificatesPages(params, func(page *acm.ListCertificatesOutput, lastPage bool) bool {
 		acmSummaries = append(acmSummaries, page.CertificateSummaryList...)
 		return true
 	})
+
+	if tag := strings.Split(filterTag, "="); len(tag) == 2 {
+		return filterCertificatesByTag(api, acmSummaries, tag[0], tag[1])
+	}
+
 	return acmSummaries, err
+}
+
+func filterCertificatesByTag(api acmiface.ACMAPI, allSummaries []*acm.CertificateSummary, key, value string) ([]*acm.CertificateSummary, error) {
+	prodSummaries := make([]*acm.CertificateSummary, 0)
+	for _, summary := range allSummaries {
+		in := &acm.ListTagsForCertificateInput{
+			CertificateArn: summary.CertificateArn,
+		}
+		out, err := api.ListTagsForCertificate(in)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, tag := range out.Tags {
+			if *tag.Key == key && *tag.Value == value {
+				prodSummaries = append(prodSummaries, summary)
+			}
+		}
+	}
+
+	return prodSummaries, nil
 }
 
 func getCertificateSummaryFromACM(api acmiface.ACMAPI, arn *string) (*certs.CertificateSummary, error) {

--- a/aws/acm.go
+++ b/aws/acm.go
@@ -49,7 +49,7 @@ func getACMCertificateSummaries(api acmiface.ACMAPI, filterTag string) ([]*acm.C
 		return true
 	})
 
-	if tag := strings.Split(filterTag, "="); len(tag) == 2 {
+	if tag := strings.Split(filterTag, "="); filterTag != "=" && len(tag) == 2 {
 		return filterCertificatesByTag(api, acmSummaries, tag[0], tag[1])
 	}
 

--- a/aws/acm_test.go
+++ b/aws/acm_test.go
@@ -39,9 +39,11 @@ func TestACM(t *testing.T) {
 						},
 					},
 				},
-				acm.GetCertificateOutput{
-					Certificate:      aws.String(cert),
-					CertificateChain: aws.String(chain),
+				map[string]*acm.GetCertificateOutput{
+					"foobar": {
+						Certificate:      aws.String(cert),
+						CertificateChain: aws.String(chain),
+					},
 				},
 			),
 			expect: acmExpect{
@@ -61,8 +63,10 @@ func TestACM(t *testing.T) {
 						},
 					},
 				},
-				acm.GetCertificateOutput{
-					Certificate: aws.String(cert),
+				map[string]*acm.GetCertificateOutput{
+					"foobar": {
+						Certificate: aws.String(cert),
+					},
 				},
 			),
 			expect: acmExpect{
@@ -72,7 +76,7 @@ func TestACM(t *testing.T) {
 			},
 		},
 		{
-			msg: "Found ACM Cert with correct filter tag",
+			msg: "Found one ACM Cert with correct filter tag",
 			api: fake.NewACMClientWithTags(
 				acm.ListCertificatesOutput{
 					CertificateSummaryList: []*acm.CertificateSummary{
@@ -80,14 +84,26 @@ func TestACM(t *testing.T) {
 							CertificateArn: aws.String("foobar"),
 							DomainName:     aws.String("foobar.de"),
 						},
+						{
+							CertificateArn: aws.String("foobaz"),
+							DomainName:     aws.String("foobar.de"),
+						},
 					},
 				},
-				acm.GetCertificateOutput{
-					Certificate: aws.String(cert),
+				map[string]*acm.GetCertificateOutput{
+					"foobar": {
+						Certificate: aws.String(cert),
+					},
+					"foobaz": {
+						Certificate: aws.String(cert),
+					},
 				},
 				map[string]*acm.ListTagsForCertificateOutput{
 					"foobar": {
 						Tags: []*acm.Tag{{Key: aws.String("production"), Value: aws.String("true")}},
+					},
+					"foobaz": {
+						Tags: []*acm.Tag{{Key: aws.String("production"), Value: aws.String("false")}},
 					},
 				},
 			),
@@ -109,8 +125,10 @@ func TestACM(t *testing.T) {
 						},
 					},
 				},
-				acm.GetCertificateOutput{
-					Certificate: aws.String(cert),
+				map[string]*acm.GetCertificateOutput{
+					"foobar": {
+						Certificate: aws.String(cert),
+					},
 				},
 				map[string]*acm.ListTagsForCertificateOutput{
 					"foobar": {

--- a/aws/acm_test.go
+++ b/aws/acm_test.go
@@ -99,7 +99,7 @@ func TestACM(t *testing.T) {
 			},
 		},
 		{
-			msg: "Found ACM Cert with incorrect filter tag",
+			msg: "ACM Cert with incorrect filter tag should not be found",
 			api: fake.NewACMClientWithTags(
 				acm.ListCertificatesOutput{
 					CertificateSummaryList: []*acm.CertificateSummary{

--- a/aws/acm_test.go
+++ b/aws/acm_test.go
@@ -15,6 +15,7 @@ type acmExpect struct {
 	DomainNames []string
 	Chain       int
 	Error       error
+	EmptyList   bool
 }
 
 func TestACM(t *testing.T) {
@@ -22,9 +23,10 @@ func TestACM(t *testing.T) {
 	chain := mustRead("chain.txt")
 
 	for _, ti := range []struct {
-		msg    string
-		api    acmiface.ACMAPI
-		expect acmExpect
+		msg       string
+		api       acmiface.ACMAPI
+		filterTag string
+		expect    acmExpect
 	}{
 		{
 			msg: "Found ACM Cert foobar and a chain",
@@ -69,9 +71,64 @@ func TestACM(t *testing.T) {
 				Error:       nil,
 			},
 		},
+		{
+			msg: "Found ACM Cert with correct filter tag",
+			api: fake.NewACMClientWithTags(
+				acm.ListCertificatesOutput{
+					CertificateSummaryList: []*acm.CertificateSummary{
+						{
+							CertificateArn: aws.String("foobar"),
+							DomainName:     aws.String("foobar.de"),
+						},
+					},
+				},
+				acm.GetCertificateOutput{
+					Certificate: aws.String(cert),
+				},
+				map[string]*acm.ListTagsForCertificateOutput{
+					"foobar": {
+						Tags: []*acm.Tag{{Key: aws.String("production"), Value: aws.String("true")}},
+					},
+				},
+			),
+			filterTag: "production=true",
+			expect: acmExpect{
+				ARN:         "foobar",
+				DomainNames: []string{"foobar.de"},
+				Error:       nil,
+			},
+		},
+		{
+			msg: "Found ACM Cert with incorrect filter tag",
+			api: fake.NewACMClientWithTags(
+				acm.ListCertificatesOutput{
+					CertificateSummaryList: []*acm.CertificateSummary{
+						{
+							CertificateArn: aws.String("foobar"),
+							DomainName:     aws.String("foobar.de"),
+						},
+					},
+				},
+				acm.GetCertificateOutput{
+					Certificate: aws.String(cert),
+				},
+				map[string]*acm.ListTagsForCertificateOutput{
+					"foobar": {
+						Tags: []*acm.Tag{{Key: aws.String("production"), Value: aws.String("false")}},
+					},
+				},
+			),
+			filterTag: "production=true",
+			expect: acmExpect{
+				EmptyList:   true,
+				ARN:         "foobar",
+				DomainNames: []string{"foobar.de"},
+				Error:       nil,
+			},
+		},
 	} {
 		t.Run(ti.msg, func(t *testing.T) {
-			provider := newACMCertProvider(ti.api)
+			provider := newACMCertProvider(ti.api, ti.filterTag)
 			list, err := provider.GetCertificates()
 
 			if ti.expect.Error != nil {
@@ -80,11 +137,16 @@ func TestACM(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			require.Equal(t, 1, len(list))
+			if ti.expect.EmptyList {
+				require.Equal(t, 0, len(list))
 
-			cert := list[0]
-			require.Equal(t, ti.expect.ARN, cert.ID())
-			require.Equal(t, ti.expect.DomainNames, cert.DomainNames())
+			} else {
+				require.Equal(t, 1, len(list))
+
+				cert := list[0]
+				require.Equal(t, ti.expect.ARN, cert.ID())
+				require.Equal(t, ti.expect.DomainNames, cert.DomainNames())
+			}
 		})
 	}
 }

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -273,12 +273,12 @@ func (a *Adapter) UpdateManifest(clusterID, vpcID string) (*Adapter, error) {
 	return a, err
 }
 
-func (a *Adapter) NewACMCertificateProvider() certs.CertificatesProvider {
-	return newACMCertProvider(a.acm)
+func (a *Adapter) NewACMCertificateProvider(certFilterTag string) certs.CertificatesProvider {
+	return newACMCertProvider(a.acm, certFilterTag)
 }
 
-func (a *Adapter) NewIAMCertificateProvider() certs.CertificatesProvider {
-	return newIAMCertProvider(a.iam)
+func (a *Adapter) NewIAMCertificateProvider(certFilterTag string) certs.CertificatesProvider {
+	return newIAMCertProvider(a.iam, certFilterTag)
 }
 
 // WithHealthCheckPath returns the receiver adapter after changing the health check path that will be used by

--- a/aws/fake/acm.go
+++ b/aws/fake/acm.go
@@ -10,7 +10,7 @@ import (
 type ACMClient struct {
 	acmiface.ACMAPI
 	output acm.ListCertificatesOutput
-	cert   acm.GetCertificateOutput
+	cert   map[string]*acm.GetCertificateOutput
 	tags   map[string]*acm.ListTagsForCertificateOutput
 }
 
@@ -24,7 +24,7 @@ func (m ACMClient) ListCertificatesPages(input *acm.ListCertificatesInput, fn fu
 }
 
 func (m ACMClient) GetCertificate(input *acm.GetCertificateInput) (*acm.GetCertificateOutput, error) {
-	return &m.cert, nil
+	return m.cert[*input.CertificateArn], nil
 }
 
 func (m ACMClient) ListTagsForCertificate(in *acm.ListTagsForCertificateInput) (*acm.ListTagsForCertificateOutput, error) {
@@ -35,7 +35,7 @@ func (m ACMClient) ListTagsForCertificate(in *acm.ListTagsForCertificateInput) (
 	return m.tags[arn], nil
 }
 
-func NewACMClient(output acm.ListCertificatesOutput, cert acm.GetCertificateOutput) ACMClient {
+func NewACMClient(output acm.ListCertificatesOutput, cert map[string]*acm.GetCertificateOutput) ACMClient {
 	return ACMClient{
 		output: output,
 		cert:   cert,
@@ -44,7 +44,7 @@ func NewACMClient(output acm.ListCertificatesOutput, cert acm.GetCertificateOutp
 
 func NewACMClientWithTags(
 	output acm.ListCertificatesOutput,
-	cert acm.GetCertificateOutput,
+	cert map[string]*acm.GetCertificateOutput,
 	tags map[string]*acm.ListTagsForCertificateOutput,
 ) ACMClient {
 	return ACMClient{

--- a/aws/fake/acm.go
+++ b/aws/fake/acm.go
@@ -1,6 +1,8 @@
 package fake
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/aws/aws-sdk-go/service/acm/acmiface"
 )
@@ -9,6 +11,7 @@ type ACMClient struct {
 	acmiface.ACMAPI
 	output acm.ListCertificatesOutput
 	cert   acm.GetCertificateOutput
+	tags   map[string]*acm.ListTagsForCertificateOutput
 }
 
 func (m ACMClient) ListCertificates(in *acm.ListCertificatesInput) (*acm.ListCertificatesOutput, error) {
@@ -24,9 +27,29 @@ func (m ACMClient) GetCertificate(input *acm.GetCertificateInput) (*acm.GetCerti
 	return &m.cert, nil
 }
 
+func (m ACMClient) ListTagsForCertificate(in *acm.ListTagsForCertificateInput) (*acm.ListTagsForCertificateOutput, error) {
+	if in.CertificateArn == nil {
+		return nil, fmt.Errorf("expected a valid CertificateArn, got: nil")
+	}
+	arn := *in.CertificateArn
+	return m.tags[arn], nil
+}
+
 func NewACMClient(output acm.ListCertificatesOutput, cert acm.GetCertificateOutput) ACMClient {
 	return ACMClient{
 		output: output,
 		cert:   cert,
+	}
+}
+
+func NewACMClientWithTags(
+	output acm.ListCertificatesOutput,
+	cert acm.GetCertificateOutput,
+	tags map[string]*acm.ListTagsForCertificateOutput,
+) ACMClient {
+	return ACMClient{
+		output: output,
+		cert:   cert,
+		tags:   tags,
 	}
 }

--- a/aws/fake/iam.go
+++ b/aws/fake/iam.go
@@ -1,6 +1,8 @@
 package fake
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 )
@@ -9,6 +11,7 @@ type IAMClient struct {
 	iamiface.IAMAPI
 	list iam.ListServerCertificatesOutput
 	cert iam.GetServerCertificateOutput
+	tags map[string]*iam.ListServerCertificateTagsOutput
 }
 
 func (m IAMClient) ListServerCertificates(*iam.ListServerCertificatesInput) (*iam.ListServerCertificatesOutput, error) {
@@ -20,6 +23,17 @@ func (m IAMClient) ListServerCertificatesPages(input *iam.ListServerCertificates
 	return nil
 }
 
+func (m IAMClient) ListServerCertificateTags(
+	in *iam.ListServerCertificateTagsInput,
+) (*iam.ListServerCertificateTagsOutput, error) {
+
+	if in.ServerCertificateName == nil {
+		return nil, fmt.Errorf("expected a valid CertificateArn, got: nil")
+	}
+	name := *in.ServerCertificateName
+	return m.tags[name], nil
+}
+
 func (m IAMClient) GetServerCertificate(*iam.GetServerCertificateInput) (*iam.GetServerCertificateOutput, error) {
 	return &m.cert, nil
 }
@@ -28,5 +42,17 @@ func NewIAMClient(list iam.ListServerCertificatesOutput, cert iam.GetServerCerti
 	return IAMClient{
 		list: list,
 		cert: cert,
+	}
+}
+
+func NewIAMClientWithTag(
+	list iam.ListServerCertificatesOutput,
+	cert iam.GetServerCertificateOutput,
+	tags map[string]*iam.ListServerCertificateTagsOutput,
+) IAMClient {
+	return IAMClient{
+		list: list,
+		cert: cert,
+		tags: tags,
 	}
 }

--- a/aws/iam.go
+++ b/aws/iam.go
@@ -27,7 +27,7 @@ func (p *iamCertificateProvider) GetCertificates() ([]*certs.CertificateSummary,
 	}
 	list := make([]*certs.CertificateSummary, 0)
 	for _, o := range serverCertificatesMetadata {
-		if kv := strings.Split(p.filterTag, "="); len(kv) == 2 {
+		if kv := strings.Split(p.filterTag, "="); p.filterTag != "=" && len(kv) == 2 {
 			hasTag, err := certHasTag(p.api, *o.ServerCertificateName, kv[0], kv[1])
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This feature aims to enable `kube-ingress-aws-controller` to ignore certificates based on tags. Effectively what this means is, you can specify a tag through the command line and the ingress controller will only use IAM/ACM certificates that have that specific tag when matching the host to define which certificate is more appropriate to add to the LB.

If a tag is not specified the ingress controller shall pick all available certificates for matching.

The main idea behind this feature is to make it very specific which certificates should be considered, this feature does not avoid incidents, but make it clearer to operators which certificates are being considered in the matching phase.

This PR addresses the issue: https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/652