### PR TITLE
aws: fail on ListCertificatesPages error

### DIFF
--- a/aws/acm.go
+++ b/aws/acm.go
@@ -44,16 +44,18 @@ func getACMCertificateSummaries(api acmiface.ACMAPI, filterTag string) ([]*acm.C
 	}
 	acmSummaries := make([]*acm.CertificateSummary, 0)
 
-	err := api.ListCertificatesPages(params, func(page *acm.ListCertificatesOutput, lastPage bool) bool {
+	if err := api.ListCertificatesPages(params, func(page *acm.ListCertificatesOutput, lastPage bool) bool {
 		acmSummaries = append(acmSummaries, page.CertificateSummaryList...)
 		return true
-	})
+	}); err != nil {
+		return nil, err
+	}
 
 	if tag := strings.Split(filterTag, "="); filterTag != "=" && len(tag) == 2 {
 		return filterCertificatesByTag(api, acmSummaries, tag[0], tag[1])
 	}
 
-	return acmSummaries, err
+	return acmSummaries, nil
 }
 
 func filterCertificatesByTag(api acmiface.ACMAPI, allSummaries []*acm.CertificateSummary, key, value string) ([]*acm.CertificateSummary, error) {

--- a/aws/acm_test.go
+++ b/aws/acm_test.go
@@ -14,7 +14,7 @@ type acmExpect struct {
 	ARN         string
 	DomainNames []string
 	Chain       int
-	Error       error
+	Error       string
 	EmptyList   bool
 }
 
@@ -45,11 +45,11 @@ func TestACM(t *testing.T) {
 						CertificateChain: aws.String(chain),
 					},
 				},
+				nil,
 			),
 			expect: acmExpect{
 				ARN:         "foobar",
 				DomainNames: []string{"foobar.de"},
-				Error:       nil,
 			},
 		},
 		{
@@ -68,16 +68,16 @@ func TestACM(t *testing.T) {
 						Certificate: aws.String(cert),
 					},
 				},
+				nil,
 			),
 			expect: acmExpect{
 				ARN:         "foobar",
 				DomainNames: []string{"foobar.de"},
-				Error:       nil,
 			},
 		},
 		{
 			msg: "Found one ACM Cert with correct filter tag",
-			api: fake.NewACMClientWithTags(
+			api: fake.NewACMClient(
 				acm.ListCertificatesOutput{
 					CertificateSummaryList: []*acm.CertificateSummary{
 						{
@@ -111,12 +111,11 @@ func TestACM(t *testing.T) {
 			expect: acmExpect{
 				ARN:         "foobar",
 				DomainNames: []string{"foobar.de"},
-				Error:       nil,
 			},
 		},
 		{
 			msg: "ACM Cert with incorrect filter tag should not be found",
-			api: fake.NewACMClientWithTags(
+			api: fake.NewACMClient(
 				acm.ListCertificatesOutput{
 					CertificateSummaryList: []*acm.CertificateSummary{
 						{
@@ -141,7 +140,6 @@ func TestACM(t *testing.T) {
 				EmptyList:   true,
 				ARN:         "foobar",
 				DomainNames: []string{"foobar.de"},
-				Error:       nil,
 			},
 		},
 	} {
@@ -149,15 +147,15 @@ func TestACM(t *testing.T) {
 			provider := newACMCertProvider(ti.api, ti.filterTag)
 			list, err := provider.GetCertificates()
 
-			if ti.expect.Error != nil {
-				require.Equal(t, ti.expect.Error, err)
+			if ti.expect.Error != "" {
+				require.EqualError(t, err, ti.expect.Error)
+				return
 			} else {
 				require.NoError(t, err)
 			}
 
 			if ti.expect.EmptyList {
 				require.Equal(t, 0, len(list))
-
 			} else {
 				require.Equal(t, 1, len(list))
 

--- a/aws/acm_test.go
+++ b/aws/acm_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -140,6 +141,18 @@ func TestACM(t *testing.T) {
 				EmptyList:   true,
 				ARN:         "foobar",
 				DomainNames: []string{"foobar.de"},
+			},
+		},
+		{
+			msg: "Fail on ListCertificatesPages error",
+			api: fake.NewACMClient(
+				acm.ListCertificatesOutput{}, nil, nil,
+			).WithListCertificatesPages(func(input *acm.ListCertificatesInput, fn func(p *acm.ListCertificatesOutput, lastPage bool) (shouldContinue bool)) error {
+				return fmt.Errorf("ListCertificatesPages error")
+			}),
+			filterTag: "production=true",
+			expect: acmExpect{
+				Error: "ListCertificatesPages error",
 			},
 		},
 	} {


### PR DESCRIPTION
`getACMCertificateSummaries` did not check `ListCertificatesPages` error
and returned empty `CertificateSummary` slice and no error
via `filterCertificatesByTag` if `filterTag` is configured.

Empty `CertificateSummary` results in empty `existingStackCertificateARNs`
for each `loadBalancer` model which triggered stack update:
```
level=info msg="Updating \"internet-facing\" stack for 0 certificates / 0 ingresses"
```
and then stack deletion on the next cycle:
```
level=info msg="Deleted orphaned stack \"kube-ingress-aws-controller-aws-XXX\""
```
due to empty certificate tags after previous update.

Follow up on https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/658