### PR TITLE
ingress-controller: update ingresses only if the load balancer is active

### DIFF
--- a/aws/acm.go
+++ b/aws/acm.go
@@ -33,7 +33,7 @@ func (p *acmCertificateProvider) GetCertificates(ctx context.Context) ([]*certs.
 	if err != nil {
 		return nil, err
 	}
-	result := make([]*certs.CertificateSummary, 0)
+	result := make([]*certs.CertificateSummary, 0, len(acmSummaries))
 	for _, o := range acmSummaries {
 		summary, err := getCertificateSummaryFromACM(ctx, p.api, o.CertificateArn)
 		if err != nil {

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -207,6 +207,7 @@ type denyResp struct {
 
 type CloudFormationAPI interface {
 	cloudformation.DescribeStacksAPIClient
+	cloudformation.ListStackResourcesAPIClient
 	CreateStack(context.Context, *cloudformation.CreateStackInput, ...func(*cloudformation.Options)) (*cloudformation.CreateStackOutput, error)
 	UpdateTerminationProtection(context.Context, *cloudformation.UpdateTerminationProtectionInput, ...func(*cloudformation.Options)) (*cloudformation.UpdateTerminationProtectionOutput, error)
 	UpdateStack(context.Context, *cloudformation.UpdateStackInput, ...func(*cloudformation.Options)) (*cloudformation.UpdateStackOutput, error)
@@ -432,6 +433,46 @@ func getStack(ctx context.Context, svc CloudFormationAPI, stackName string) (*St
 		return nil, ErrLoadBalancerStackNotReady
 	}
 	return mapToManagedStack(stack), nil
+}
+
+// getLoadBalancerStackResource retrieves the load balancer resource from a
+// CloudFormation stack. It returns the first resource of type
+// AWS::ElasticLoadBalancingV2::LoadBalancer found in the stack. The stack
+// should only have one such resource, as it is expected to be a managed load
+// balancer stack.
+func getLoadBalancerStackResource(
+	ctx context.Context,
+	svc CloudFormationAPI,
+	stackName string,
+) (
+	*types.StackResourceSummary,
+	error,
+) {
+
+	var nextToken *string
+
+	for {
+		resp, err := svc.ListStackResources(ctx, &cloudformation.ListStackResourcesInput{
+			StackName: aws.String(stackName),
+			NextToken: nextToken,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to list stack resources for stack %s: %w", stackName, err)
+		}
+
+		for _, resource := range resp.StackResourceSummaries {
+			if aws.ToString(resource.LogicalResourceId) == LoadBalancerResourceLogicalID {
+				return &resource, nil
+			}
+		}
+
+		if resp.NextToken == nil {
+			return nil, fmt.Errorf("no load balancer resource found in stack %s", stackName)
+		}
+
+		nextToken = resp.NextToken
+	}
 }
 
 func getCFStackByName(ctx context.Context, svc CloudFormationAPI, stackName string) (*types.Stack, error) {

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -24,6 +24,13 @@ const (
 	//
 	// [0]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html#cfn-elasticloadbalancingv2-listenerrule-priority
 	internalTrafficDenyRulePriority int64 = 1
+
+  // LoadBalancerResou  rceLogicalID is the logical ID of the LoadBalancer 
+  // resource in the CloudFormation template.
+  // 
+  // !!!Caution
+  //    Changing this value will recreate the LoadBalancer resource.
+	LoadBalancerResourceLogicalID = "LB"
 )
 
 func hashARNs(certARNs []string) []byte {
@@ -117,7 +124,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 	template.Outputs = map[string]*cloudformation.Output{
 		outputLoadBalancerDNSName: {
 			Description: "DNS name for the LoadBalancer",
-			Value:       cloudformation.GetAtt("LB", "DNSName").String(),
+			Value:       cloudformation.GetAtt(LoadBalancerResourceLogicalID, "DNSName").String(),
 		},
 		outputTargetGroupARN: {
 			Description: "The ARN of the TargetGroup",
@@ -160,7 +167,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 							},
 						},
 					},
-					LoadBalancerArn: cloudformation.Ref("LB").String(),
+					LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 					Port:            cloudformation.Integer(80),
 					Protocol:        cloudformation.String("HTTP"),
 				})
@@ -172,7 +179,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 							TargetGroupArn: cloudformation.Ref(httpTargetGroupName).String(),
 						},
 					},
-					LoadBalancerArn: cloudformation.Ref("LB").String(),
+					LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 					Port:            cloudformation.Integer(80),
 					Protocol:        cloudformation.String("HTTP"),
 				})
@@ -196,7 +203,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 						TargetGroupArn: cloudformation.Ref(httpTargetGroupName).String(),
 					},
 				},
-				LoadBalancerArn: cloudformation.Ref("LB").String(),
+				LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				Port:            cloudformation.Integer(80),
 				Protocol:        cloudformation.String("TCP"),
 			})
@@ -227,7 +234,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 						CertificateArn: cloudformation.String(certificateARNs[0]),
 					},
 				},
-				LoadBalancerArn: cloudformation.Ref("LB").String(),
+				LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				Port:            cloudformation.Integer(443),
 				Protocol:        cloudformation.String("HTTPS"),
 				SslPolicy:       cloudformation.Ref(parameterListenerSslPolicyParameter).String(),
@@ -256,7 +263,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 						CertificateArn: cloudformation.String(certificateARNs[0]),
 					},
 				},
-				LoadBalancerArn: cloudformation.Ref("LB").String(),
+				LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				Port:            cloudformation.Integer(443),
 				Protocol:        cloudformation.String("TLS"),
 				SslPolicy:       cloudformation.Ref(parameterListenerSslPolicyParameter).String(),
@@ -379,17 +386,17 @@ func generateTemplate(spec *stackSpec) (string, error) {
 		lb.Type = cloudformation.Ref(parameterLoadBalancerTypeParameter).String()
 	}
 
-	template.AddResource("LB", lb)
+	template.AddResource(LoadBalancerResourceLogicalID, lb)
 
 	if spec.loadbalancerType == LoadBalancerTypeApplication && spec.wafWebAclId != "" {
 		if strings.HasPrefix(spec.wafWebAclId, "arn:aws:wafv2:") {
 			template.AddResource("WAFAssociation", &cloudformation.WAFv2WebACLAssociation{
-				ResourceArn: cloudformation.Ref("LB").String(),
+				ResourceArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				WebACLArn:   cloudformation.Ref(parameterLoadBalancerWAFWebACLIDParameter).String(),
 			})
 		} else {
 			template.AddResource("WAFAssociation", &cloudformation.WAFRegionalWebACLAssociation{
-				ResourceArn: cloudformation.Ref("LB").String(),
+				ResourceArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				WebACLID:    cloudformation.Ref(parameterLoadBalancerWAFWebACLIDParameter).String(),
 			})
 		}

--- a/aws/cf_template_test.go
+++ b/aws/cf_template_test.go
@@ -123,7 +123,7 @@ func TestGenerateTemplate(t *testing.T) {
 					&cloudformation.CloudWatchAlarmDimensionList{
 						{
 							Name:  cloudformation.String("LoadBalancer"),
-							Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+							Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 						},
 					},
 					props.Dimensions,
@@ -270,8 +270,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbCrossZone:     true,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[0].Key.Literal, "load_balancing.cross_zone.enabled")
 				require.Equal(t, attributes[0].Value.Literal, "true")
@@ -284,8 +284,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbCrossZone:     false,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[0].Key.Literal, "load_balancing.cross_zone.enabled")
 				require.Equal(t, attributes[0].Value.Literal, "false")
@@ -298,8 +298,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbZoneAffinity:  "any_availability_zone",
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "dns_record.client_routing_policy")
 				require.Equal(t, attributes[1].Value.Literal, "any_availability_zone")
@@ -312,8 +312,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbZoneAffinity:  "availability_zone_affinity",
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "dns_record.client_routing_policy")
 				require.Equal(t, attributes[1].Value.Literal, "availability_zone_affinity")
@@ -326,8 +326,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbZoneAffinity:  "partial_availability_zone_affinity",
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "dns_record.client_routing_policy")
 				require.Equal(t, attributes[1].Value.Literal, "partial_availability_zone_affinity")
@@ -352,8 +352,8 @@ func TestGenerateTemplate(t *testing.T) {
 				http2:            true,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "routing.http2.enabled")
 				require.Equal(t, attributes[1].Value.Literal, "true")
@@ -366,8 +366,8 @@ func TestGenerateTemplate(t *testing.T) {
 				http2:            false,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "routing.http2.enabled")
 				require.Equal(t, attributes[1].Value.Literal, "false")

--- a/aws/cf_test.go
+++ b/aws/cf_test.go
@@ -784,6 +784,84 @@ func TestGetStack(t *testing.T) {
 	}
 }
 
+func TestGetLoadBalancerStackResource(t *testing.T) {
+
+	for _, ti := range []struct {
+		name    string
+		given   fake.CFOutputs
+		want    *types.StackResourceSummary
+		wantErr bool
+	}{
+		{
+			"managed load balancer resource found",
+			fake.CFOutputs{
+				ListStackResources: fake.R(&cloudformation.ListStackResourcesOutput{
+					StackResourceSummaries: []types.StackResourceSummary{
+						{
+							LogicalResourceId:    aws.String(LoadBalancerResourceLogicalID),
+							ResourceType:         aws.String("AWS::ElasticLoadBalancingV2::LoadBalancer"),
+							ResourceStatus:       types.ResourceStatusCreateComplete,
+							ResourceStatusReason: aws.String(""),
+						},
+					}}, nil),
+			},
+			&types.StackResourceSummary{
+				LogicalResourceId:    aws.String(LoadBalancerResourceLogicalID),
+				ResourceType:         aws.String("AWS::ElasticLoadBalancingV2::LoadBalancer"),
+				ResourceStatus:       types.ResourceStatusCreateComplete,
+				ResourceStatusReason: aws.String(""),
+			},
+			false,
+		},
+		{
+			"no load balancer resource",
+			fake.CFOutputs{
+				ListStackResources: fake.R(&cloudformation.ListStackResourcesOutput{
+					StackResourceSummaries: []types.StackResourceSummary{
+						{
+							LogicalResourceId:    aws.String("SomeOtherResourceLogicalID"),
+							ResourceType:         aws.String("AWS::Some::OtherResource"),
+							ResourceStatus:       types.ResourceStatusCreateComplete,
+							ResourceStatusReason: aws.String(""),
+						},
+					}}, nil),
+			},
+			nil,
+			true,
+		},
+		{
+			"unmanaged load balancer",
+			fake.CFOutputs{
+				ListStackResources: fake.R(&cloudformation.ListStackResourcesOutput{
+					StackResourceSummaries: []types.StackResourceSummary{
+						{
+							LogicalResourceId:    aws.String("unmanaged-load-balancer"),
+							ResourceType:         aws.String("AWS::ElasticLoadBalancingV2::LoadBalancer"),
+							ResourceStatus:       types.ResourceStatusCreateComplete,
+							ResourceStatusReason: aws.String(""),
+						},
+					}}, nil),
+			},
+			nil,
+			true,
+		},
+	} {
+		t.Run(ti.name, func(t *testing.T) {
+			c := &fake.CFClient{Outputs: ti.given}
+			got, err := getLoadBalancerStackResource(context.Background(), c, "dontcare")
+			if err != nil {
+				if !ti.wantErr {
+					t.Error("unexpected error", err)
+				}
+			} else {
+				if !reflect.DeepEqual(ti.want, got) {
+					t.Errorf("unexpected result. wanted %+v, got %+v", ti.want, got)
+				}
+			}
+		})
+	}
+}
+
 func TestShouldDelete(t *testing.T) {
 	for _, ti := range []struct {
 		msg   string

--- a/aws/cloudwatch.go
+++ b/aws/cloudwatch.go
@@ -77,7 +77,7 @@ func normalizeCloudWatchAlarmDimensions(alarmDimensions *cloudformation.CloudWat
 		return &cloudformation.CloudWatchAlarmDimensionList{
 			{
 				Name:  cloudformation.String("LoadBalancer"),
-				Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+				Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 			},
 		}
 	}
@@ -89,7 +89,7 @@ func normalizeCloudWatchAlarmDimensions(alarmDimensions *cloudformation.CloudWat
 
 		switch dimension.Name.Literal {
 		case "LoadBalancer":
-			value = cloudformation.GetAtt("LB", "LoadBalancerFullName").String()
+			value = cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String()
 		case "TargetGroup":
 			value = cloudformation.GetAtt("TG", "TargetGroupFullName").String()
 		}

--- a/aws/cloudwatch_test.go
+++ b/aws/cloudwatch_test.go
@@ -103,7 +103,7 @@ func TestNormalizeCloudWatchAlarmDimensions(t *testing.T) {
 			expected: &cloudformation.CloudWatchAlarmDimensionList{
 				{
 					Name:  cloudformation.String("LoadBalancer"),
-					Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+					Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 				},
 			},
 		},
@@ -113,7 +113,7 @@ func TestNormalizeCloudWatchAlarmDimensions(t *testing.T) {
 			expected: &cloudformation.CloudWatchAlarmDimensionList{
 				{
 					Name:  cloudformation.String("LoadBalancer"),
-					Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+					Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 				},
 			},
 		},
@@ -135,7 +135,7 @@ func TestNormalizeCloudWatchAlarmDimensions(t *testing.T) {
 			expected: &cloudformation.CloudWatchAlarmDimensionList{
 				{
 					Name:  cloudformation.String("LoadBalancer"),
-					Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+					Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 				},
 				{
 					Name:  cloudformation.String("TargetGroup"),

--- a/aws/elbv2_test.go
+++ b/aws/elbv2_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2Types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 
 	"github.com/zalando-incubator/kube-ingress-aws-controller/aws/fake"
 )
@@ -206,4 +210,167 @@ func TestDeregisterTargetsOnTargetGroups(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetLoadBalancer(t *testing.T) {
+	for _, ti := range []struct {
+		name           string
+		givenCFOutput  fake.CFOutputs
+		givenELBOutput fake.ELBv2Outputs
+		wantELB        *elbv2Types.LoadBalancer
+		wantError      bool
+	}{
+		{
+			"one active managed load balancer",
+			fake.CFOutputs{
+				ListStackResources: fake.R(
+					&cloudformation.ListStackResourcesOutput{
+						StackResourceSummaries: []types.StackResourceSummary{
+							{
+								LogicalResourceId:  aws.String(LoadBalancerResourceLogicalID),
+								ResourceType:       aws.String("AWS::ElasticLoadBalancingV2::LoadBalancer"),
+								PhysicalResourceId: aws.String("myELB"),
+							},
+						},
+					}, nil),
+			},
+			fake.ELBv2Outputs{
+				DescribeLoadBalancers: fake.R(
+					&elbv2.DescribeLoadBalancersOutput{
+						LoadBalancers: []elbv2Types.LoadBalancer{
+							{
+								LoadBalancerArn: aws.String("aws-arn-with-myELB-physical-id"),
+								State: &elbv2Types.LoadBalancerState{
+									Code:   elbv2Types.LoadBalancerStateEnumActive,
+									Reason: aws.String(""),
+								},
+							},
+						},
+					}, nil),
+			},
+			&elbv2Types.LoadBalancer{
+				LoadBalancerArn: aws.String("aws-arn-with-myELB-physical-id"),
+				State: &elbv2Types.LoadBalancerState{
+					Code:   elbv2Types.LoadBalancerStateEnumActive,
+					Reason: aws.String(""),
+				},
+			},
+			false,
+		},
+		{
+			"error when listing aws stack resources",
+			fake.CFOutputs{
+				ListStackResources: fake.R(nil, fake.ErrDummy),
+			},
+			fake.ELBv2Outputs{
+				DescribeLoadBalancers: fake.R(nil, nil),
+			},
+			nil,
+			true,
+		},
+		{
+			"error when describing aws load balancers",
+			fake.CFOutputs{
+				ListStackResources: fake.R(
+					&cloudformation.ListStackResourcesOutput{
+						StackResourceSummaries: []types.StackResourceSummary{
+							{
+								LogicalResourceId:  aws.String(LoadBalancerResourceLogicalID),
+								ResourceType:       aws.String("AWS::ElasticLoadBalancingV2::LoadBalancer"),
+								PhysicalResourceId: aws.String("myELB"),
+							},
+						},
+					}, nil),
+			},
+			fake.ELBv2Outputs{
+				DescribeLoadBalancers: fake.R(nil, fake.ErrDummy),
+			},
+			nil,
+			true,
+		},
+		{
+			"stack has load balancer resource but no load balancer",
+			fake.CFOutputs{
+				ListStackResources: fake.R(
+					&cloudformation.ListStackResourcesOutput{
+						StackResourceSummaries: []types.StackResourceSummary{
+							{
+								LogicalResourceId:  aws.String(LoadBalancerResourceLogicalID),
+								ResourceType:       aws.String("AWS::ElasticLoadBalancingV2::LoadBalancer"),
+								PhysicalResourceId: aws.String("myELB"),
+							},
+						},
+					}, nil),
+			},
+			fake.ELBv2Outputs{
+				DescribeLoadBalancers: fake.R(
+					&elbv2.DescribeLoadBalancersOutput{
+						LoadBalancers: []elbv2Types.LoadBalancer{},
+					}, nil),
+			},
+			nil,
+			true,
+		},
+		{
+			"multiple load balancers",
+			fake.CFOutputs{
+				ListStackResources: fake.R(
+					&cloudformation.ListStackResourcesOutput{
+						StackResourceSummaries: []types.StackResourceSummary{
+							{
+								LogicalResourceId:  aws.String(LoadBalancerResourceLogicalID),
+								ResourceType:       aws.String("AWS::ElasticLoadBalancingV2::LoadBalancer"),
+								PhysicalResourceId: aws.String("myELB"),
+							},
+						},
+					}, nil),
+			},
+			fake.ELBv2Outputs{
+				DescribeLoadBalancers: fake.R(
+					&elbv2.DescribeLoadBalancersOutput{
+						LoadBalancers: []elbv2Types.LoadBalancer{
+							{
+								LoadBalancerArn: aws.String("aws-arn-with-myELB-physical-id-002"),
+								State: &elbv2Types.LoadBalancerState{
+									Code:   elbv2Types.LoadBalancerStateEnumActive,
+									Reason: aws.String(""),
+								},
+							},
+							{
+								LoadBalancerArn: aws.String("aws-arn-with-myELB-physical-id-001"),
+								State: &elbv2Types.LoadBalancerState{
+									Code:   elbv2Types.LoadBalancerStateEnumFailed,
+									Reason: aws.String("cannot create the load balancer"),
+								},
+							},
+						},
+					}, nil),
+			},
+			nil,
+			true,
+		},
+	} {
+		t.Run(ti.name, func(t *testing.T) {
+			svc := &fake.ELBv2Client{Outputs: ti.givenELBOutput}
+			cfSvc := &fake.CFClient{Outputs: ti.givenCFOutput}
+
+			a := Adapter{
+				elbv2:          svc,
+				cloudformation: cfSvc,
+			}
+
+			elb, err := a.GetLoadBalancer(context.Background(), "myELB")
+			if ti.wantError && err == nil {
+				t.Fatalf("expected error, got nothing")
+			}
+			if !ti.wantError && err != nil {
+				t.Fatalf("unexpected error - %q", err)
+			}
+			if !ti.wantError && !reflect.DeepEqual(elb, ti.wantELB) {
+				t.Errorf("unexpected ELB. expected: %v, got: %v", ti.wantELB, elb)
+			}
+		},
+		)
+	}
+
 }

--- a/aws/fake/cf.go
+++ b/aws/fake/cf.go
@@ -10,6 +10,7 @@ import (
 
 type CFOutputs struct {
 	DescribeStacks              *APIResponse
+	ListStackResources          *APIResponse
 	CreateStack                 *APIResponse
 	UpdateStack                 *APIResponse
 	DeleteStack                 *APIResponse
@@ -48,6 +49,14 @@ func (m *CFClient) DescribeStacks(context.Context, *cloudformation.DescribeStack
 		return nil, m.Outputs.DescribeStacks.err
 	}
 	return out, m.Outputs.DescribeStacks.err
+}
+
+func (m *CFClient) ListStackResources(ctx context.Context, params *cloudformation.ListStackResourcesInput, fn ...func(*cloudformation.Options)) (*cloudformation.ListStackResourcesOutput, error) {
+	out, ok := m.Outputs.ListStackResources.response.(*cloudformation.ListStackResourcesOutput)
+	if !ok {
+		return nil, m.Outputs.ListStackResources.err
+	}
+	return out, m.Outputs.ListStackResources.err
 }
 
 func MockDescribeStacksOutput(stackId *string) *cloudformation.DescribeStacksOutput {

--- a/aws/fake/elbv2.go
+++ b/aws/fake/elbv2.go
@@ -7,11 +7,12 @@ import (
 )
 
 type ELBv2Outputs struct {
-	RegisterTargets      *APIResponse
-	DeregisterTargets    *APIResponse
-	DescribeTags         *APIResponse
-	DescribeTargetGroups *APIResponse
-	DescribeTargetHealth *APIResponse
+	RegisterTargets       *APIResponse
+	DeregisterTargets     *APIResponse
+	DescribeTags          *APIResponse
+	DescribeTargetGroups  *APIResponse
+	DescribeTargetHealth  *APIResponse
+	DescribeLoadBalancers *APIResponse
 }
 
 type ELBv2Client struct {
@@ -64,6 +65,14 @@ func (m *ELBv2Client) DescribeTargetGroups(context.Context, *elbv2.DescribeTarge
 		return nil, m.Outputs.DescribeTargetGroups.err
 	}
 	return out, m.Outputs.DescribeTargetGroups.err
+}
+
+func (m *ELBv2Client) DescribeLoadBalancers(context.Context, *elbv2.DescribeLoadBalancersInput, ...func(*elbv2.Options)) (*elbv2.DescribeLoadBalancersOutput, error) {
+	out, ok := m.Outputs.DescribeLoadBalancers.response.(*elbv2.DescribeLoadBalancersOutput)
+	if !ok {
+		return nil, m.Outputs.DescribeLoadBalancers.err
+	}
+	return out, m.Outputs.DescribeLoadBalancers.err
 }
 
 func MockDescribeTargetGroupsOutput() *elbv2.DescribeTargetGroupsOutput {

--- a/testdata/no_certificates/input/k8s/ing.yaml
+++ b/testdata/no_certificates/input/k8s/ing.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: no_certificates
+spec:
+  rules:
+  - host: foo.bar.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: foo-bar-service
+            port:
+              name: main-port
+        path: /
+        pathType: ImplementationSpecific

--- a/worker.go
+++ b/worker.go
@@ -318,6 +318,10 @@ func doWork(
 		return problems.Add("failed to get certificates: %w", err)
 	}
 
+	if len(certificateSummaries) == 0 {
+		return problems.Add("no certificates found")
+	}
+
 	cwAlarms, err := getCloudWatchAlarms(kubeAdapter, cwAlarmConfigMapLocation)
 	if err != nil {
 		return problems.Add("failed to retrieve cloudwatch alarm configuration: %w", err)

--- a/worker_test.go
+++ b/worker_test.go
@@ -39,6 +39,16 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 	// See https://github.com/aws/aws-sdk-go-v2/blob/main/service/ec2/types/types.go, type InstanceState
 	running := int32(16)
 
+	ca, err := certsfake.NewCA()
+	require.NoError(tt, err)
+
+	certSummary, err := ca.NewCertificateSummary()
+	require.NoError(tt, err)
+
+	var certsProvider certs.CertificatesProvider = &certsfake.CertificateProvider{
+		Summaries: []*certs.CertificateSummary{certSummary},
+	}
+
 	for _, scenario := range []struct {
 		name           string
 		responsesEC2   fake.EC2Outputs
@@ -514,7 +524,7 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 			}
 
 			log.SetLevel(log.DebugLevel)
-			problems := doWork(ctx, &certsfake.CertificateProvider{}, 10, time.Hour, a, k, "")
+			problems := doWork(ctx, certsProvider, 10, time.Hour, a, k, "")
 			if len(problems.Errors()) > 0 {
 				t.Error(problems.Errors())
 			}

--- a/worker_test.go
+++ b/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http/httptest"
 	"os"
@@ -50,15 +51,20 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 	}
 
 	for _, scenario := range []struct {
-		name           string
+		name   string
+		typeLB string
+		// mock
 		responsesEC2   fake.EC2Outputs
 		responsesASG   fake.ASGOutputs
 		responsesELBv2 fake.ELBv2Outputs
 		responsesCF    fake.CFOutputs
-		typeLB         string
+		certsProvider  certs.CertificatesProvider
+		// expect
+		problems []string
 	}{
 		{
-			name: "ingress_alb",
+			name:   "ingress_alb",
+			typeLB: aws.LoadBalancerTypeApplication,
 			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
 				fake.TestInstance{
 					Id:        "i0",
@@ -106,60 +112,11 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
 				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
 			},
-			typeLB: aws.LoadBalancerTypeApplication,
+			certsProvider: certsProvider,
 		},
 		{
-			name: "ingress_nlb",
-			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
-				fake.TestInstance{
-					Id:        "i0",
-					Tags:      fake.Tags{"aws:autoscaling:groupName": "asg1", clusterIDTagPrefix + clusterID: "owned"},
-					PrivateIp: "1.2.3.3",
-					VpcId:     vpcID,
-					State:     running,
-				},
-				fake.TestInstance{
-					Id:        "i1",
-					Tags:      fake.Tags{"aws:autoscaling:groupName": "asg1", clusterIDTagPrefix + clusterID: "owned"},
-					PrivateIp: "1.2.3.4",
-					VpcId:     vpcID,
-					State:     running,
-				},
-				fake.TestInstance{
-					Id:        "i2",
-					Tags:      fake.Tags{"aws:autoscaling:groupName": "asg1", clusterIDTagPrefix + clusterID: "owned"},
-					PrivateIp: "1.2.3.5",
-					VpcId:     vpcID,
-					State:     running,
-				}), nil),
-				DescribeSecurityGroups: fake.R(fake.MockDescribeSecurityGroupsOutput(map[string]string{"id": securityGroupID}), nil),
-				DescribeSubnets: fake.R(fake.MockDescribeSubnetsOutput(
-					fake.TestSubnet{Id: "foo1", Name: "bar1", Az: "baz1", Tags: map[string]string{"kubernetes.io/role/elb": ""}}), nil),
-				DescribeRouteTables: fake.R(fake.MockDescribeRouteTableOutput(
-					fake.TestRouteTable{SubnetID: "foo1", GatewayIds: []string{"igw-foo1"}},
-					fake.TestRouteTable{SubnetID: "mismatch", GatewayIds: []string{"igw-foo2"}, Main: true},
-				), nil),
-			},
-			responsesASG: fake.ASGOutputs{
-				DescribeAutoScalingGroups: fake.R(fake.MockDescribeAutoScalingGroupOutput(map[string]fake.ASGtags{"asg1": {
-					clusterIDTagPrefix + clusterID: "owned",
-				}}), nil),
-				DescribeLoadBalancerTargetGroups: fake.R(&autoscaling.DescribeLoadBalancerTargetGroupsOutput{
-					LoadBalancerTargetGroups: []autoScalingTypes.LoadBalancerTargetGroupState{},
-				}, nil),
-				AttachLoadBalancerTargetGroups: fake.R(nil, nil),
-			},
-			responsesELBv2: fake.ELBv2Outputs{
-				DescribeTargetGroups: fake.R(fake.MockDescribeTargetGroupsOutput(), nil),
-				DescribeTags:         fake.R(nil, nil),
-			},
-			responsesCF: fake.CFOutputs{
-				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
-				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
-			},
+			name:   "ingress_nlb",
 			typeLB: aws.LoadBalancerTypeNetwork,
-		}, {
-			name: "rg_alb",
 			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
 				fake.TestInstance{
 					Id:        "i0",
@@ -207,9 +164,10 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
 				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
 			},
+			certsProvider: certsProvider,
+		}, {
+			name:   "rg_alb",
 			typeLB: aws.LoadBalancerTypeApplication,
-		}, {
-			name: "rg_nlb",
 			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
 				fake.TestInstance{
 					Id:        "i0",
@@ -257,9 +215,10 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
 				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
 			},
+			certsProvider: certsProvider,
+		}, {
+			name:   "rg_nlb",
 			typeLB: aws.LoadBalancerTypeNetwork,
-		}, {
-			name: "ing_shared_rg_notshared_alb",
 			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
 				fake.TestInstance{
 					Id:        "i0",
@@ -307,9 +266,10 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
 				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
 			},
+			certsProvider: certsProvider,
+		}, {
+			name:   "ing_shared_rg_notshared_alb",
 			typeLB: aws.LoadBalancerTypeApplication,
-		}, {
-			name: "ingress_rg_shared_alb",
 			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
 				fake.TestInstance{
 					Id:        "i0",
@@ -357,9 +317,10 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
 				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
 			},
+			certsProvider: certsProvider,
+		}, {
+			name:   "ingress_rg_shared_alb",
 			typeLB: aws.LoadBalancerTypeApplication,
-		}, {
-			name: "ingress_rg_shared_nlb",
 			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
 				fake.TestInstance{
 					Id:        "i0",
@@ -407,59 +368,146 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
 				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
 			},
+			certsProvider: certsProvider,
+		}, {
+			name:   "ingress_rg_shared_nlb",
 			typeLB: aws.LoadBalancerTypeNetwork,
+			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
+				fake.TestInstance{
+					Id:        "i0",
+					Tags:      fake.Tags{"aws:autoscaling:groupName": "asg1", clusterIDTagPrefix + clusterID: "owned"},
+					PrivateIp: "1.2.3.3",
+					VpcId:     vpcID,
+					State:     running,
+				},
+				fake.TestInstance{
+					Id:        "i1",
+					Tags:      fake.Tags{"aws:autoscaling:groupName": "asg1", clusterIDTagPrefix + clusterID: "owned"},
+					PrivateIp: "1.2.3.4",
+					VpcId:     vpcID,
+					State:     running,
+				},
+				fake.TestInstance{
+					Id:        "i2",
+					Tags:      fake.Tags{"aws:autoscaling:groupName": "asg1", clusterIDTagPrefix + clusterID: "owned"},
+					PrivateIp: "1.2.3.5",
+					VpcId:     vpcID,
+					State:     running,
+				}), nil),
+				DescribeSecurityGroups: fake.R(fake.MockDescribeSecurityGroupsOutput(map[string]string{"id": securityGroupID}), nil),
+				DescribeSubnets: fake.R(fake.MockDescribeSubnetsOutput(
+					fake.TestSubnet{Id: "foo1", Name: "bar1", Az: "baz1", Tags: map[string]string{"kubernetes.io/role/elb": ""}}), nil),
+				DescribeRouteTables: fake.R(fake.MockDescribeRouteTableOutput(
+					fake.TestRouteTable{SubnetID: "foo1", GatewayIds: []string{"igw-foo1"}},
+					fake.TestRouteTable{SubnetID: "mismatch", GatewayIds: []string{"igw-foo2"}, Main: true},
+				), nil),
+			},
+			responsesASG: fake.ASGOutputs{
+				DescribeAutoScalingGroups: fake.R(fake.MockDescribeAutoScalingGroupOutput(map[string]fake.ASGtags{"asg1": {
+					clusterIDTagPrefix + clusterID: "owned",
+				}}), nil),
+				DescribeLoadBalancerTargetGroups: fake.R(&autoscaling.DescribeLoadBalancerTargetGroupsOutput{
+					LoadBalancerTargetGroups: []autoScalingTypes.LoadBalancerTargetGroupState{},
+				}, nil),
+				AttachLoadBalancerTargetGroups: fake.R(nil, nil),
+			},
+			responsesELBv2: fake.ELBv2Outputs{
+				DescribeTargetGroups: fake.R(fake.MockDescribeTargetGroupsOutput(), nil),
+				DescribeTags:         fake.R(nil, nil),
+			},
+			responsesCF: fake.CFOutputs{
+				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
+				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
+			},
+			certsProvider: certsProvider,
+		},
+		{
+			name:   "no_certificates",
+			typeLB: aws.LoadBalancerTypeApplication,
+			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
+				fake.TestInstance{
+					Id:        "i0",
+					Tags:      fake.Tags{"aws:autoscaling:groupName": "asg1", clusterIDTagPrefix + clusterID: "owned"},
+					PrivateIp: "1.2.3.3",
+					VpcId:     vpcID,
+					State:     running,
+				}), nil),
+				DescribeSecurityGroups: fake.R(fake.MockDescribeSecurityGroupsOutput(map[string]string{"id": securityGroupID}), nil),
+				DescribeSubnets: fake.R(fake.MockDescribeSubnetsOutput(
+					fake.TestSubnet{Id: "foo1", Name: "bar1", Az: "baz1", Tags: map[string]string{"kubernetes.io/role/elb": ""}}), nil),
+				DescribeRouteTables: fake.R(fake.MockDescribeRouteTableOutput(
+					fake.TestRouteTable{SubnetID: "foo1", GatewayIds: []string{"igw-foo1"}},
+					fake.TestRouteTable{SubnetID: "mismatch", GatewayIds: []string{"igw-foo2"}, Main: true},
+				), nil),
+			},
+			responsesASG: fake.ASGOutputs{
+				DescribeAutoScalingGroups: fake.R(fake.MockDescribeAutoScalingGroupOutput(map[string]fake.ASGtags{"asg1": {
+					clusterIDTagPrefix + clusterID: "owned",
+				}}), nil),
+				DescribeLoadBalancerTargetGroups: fake.R(&autoscaling.DescribeLoadBalancerTargetGroupsOutput{
+					LoadBalancerTargetGroups: []autoScalingTypes.LoadBalancerTargetGroupState{},
+				}, nil),
+				AttachLoadBalancerTargetGroups: fake.R(nil, nil),
+			},
+			responsesELBv2: fake.ELBv2Outputs{
+				DescribeTargetGroups: fake.R(fake.MockDescribeTargetGroupsOutput(), nil),
+				DescribeTags:         fake.R(nil, nil),
+			},
+			responsesCF: fake.CFOutputs{
+				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
+				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
+			},
+			certsProvider: &certsfake.CertificateProvider{
+				Summaries: nil,
+				Error:     fmt.Errorf("something went wrong"),
+			},
+			problems: []string{"failed to get certificates: something went wrong"},
+		},
+		{
+			name:   "no_certificates",
+			typeLB: aws.LoadBalancerTypeApplication,
+			responsesEC2: fake.EC2Outputs{DescribeInstances: fake.R(fake.MockDescribeInstancesOutput(
+				fake.TestInstance{
+					Id:        "i0",
+					Tags:      fake.Tags{"aws:autoscaling:groupName": "asg1", clusterIDTagPrefix + clusterID: "owned"},
+					PrivateIp: "1.2.3.3",
+					VpcId:     vpcID,
+					State:     running,
+				}), nil),
+				DescribeSecurityGroups: fake.R(fake.MockDescribeSecurityGroupsOutput(map[string]string{"id": securityGroupID}), nil),
+				DescribeSubnets: fake.R(fake.MockDescribeSubnetsOutput(
+					fake.TestSubnet{Id: "foo1", Name: "bar1", Az: "baz1", Tags: map[string]string{"kubernetes.io/role/elb": ""}}), nil),
+				DescribeRouteTables: fake.R(fake.MockDescribeRouteTableOutput(
+					fake.TestRouteTable{SubnetID: "foo1", GatewayIds: []string{"igw-foo1"}},
+					fake.TestRouteTable{SubnetID: "mismatch", GatewayIds: []string{"igw-foo2"}, Main: true},
+				), nil),
+			},
+			responsesASG: fake.ASGOutputs{
+				DescribeAutoScalingGroups: fake.R(fake.MockDescribeAutoScalingGroupOutput(map[string]fake.ASGtags{"asg1": {
+					clusterIDTagPrefix + clusterID: "owned",
+				}}), nil),
+				DescribeLoadBalancerTargetGroups: fake.R(&autoscaling.DescribeLoadBalancerTargetGroupsOutput{
+					LoadBalancerTargetGroups: []autoScalingTypes.LoadBalancerTargetGroupState{},
+				}, nil),
+				AttachLoadBalancerTargetGroups: fake.R(nil, nil),
+			},
+			responsesELBv2: fake.ELBv2Outputs{
+				DescribeTargetGroups: fake.R(fake.MockDescribeTargetGroupsOutput(), nil),
+				DescribeTags:         fake.R(nil, nil),
+			},
+			responsesCF: fake.CFOutputs{
+				DescribeStacks: fake.R(fake.MockDescribeStacksOutput(nil), nil),
+				CreateStack:    fake.R(fake.MockCSOutput("42"), nil),
+			},
+			certsProvider: &certsfake.CertificateProvider{
+				Summaries: []*certs.CertificateSummary{},
+				Error:     nil,
+			},
+			problems: []string{"no certificates found"},
 		},
 	} {
 		tt.Run(scenario.name, func(t *testing.T) {
 			ctx := context.Background()
-			readFile := func(fileName string) []byte {
-				b, err := os.ReadFile("./testdata/" + scenario.name + "/output/" + fileName)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				return b
-			}
-
-			var templates []string
-			templateFiles, err := os.ReadDir("./testdata/" + scenario.name + "/output/templates/")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			for _, file := range templateFiles {
-				templates = append(templates, string(readFile("templates/"+file.Name())))
-			}
-
-			paramFiles, err := os.ReadDir("./testdata/" + scenario.name + "/output/params/")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			var params [][]cfTypes.Parameter
-			for _, file := range paramFiles {
-				var content []cfTypes.Parameter
-				err := json.Unmarshal(readFile("params/"+file.Name()), &content)
-				if err != nil {
-					t.Fatal(err)
-				}
-				params = append(params, content)
-			}
-
-			tagFiles, err := os.ReadDir("./testdata/" + scenario.name + "/output/tags/")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			var tags [][]cfTypes.Tag
-			for _, file := range tagFiles {
-				var content []cfTypes.Tag
-				err := json.Unmarshal(readFile("tags/"+file.Name()), &content)
-				if err != nil {
-					t.Fatal(err)
-				}
-				tags = append(tags, content)
-			}
 
 			clientEC2 := &fake.EC2Client{Outputs: scenario.responsesEC2}
 			clientASG := &fake.ASGClient{Outputs: scenario.responsesASG}
@@ -524,9 +572,66 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 			}
 
 			log.SetLevel(log.DebugLevel)
-			problems := doWork(ctx, certsProvider, 10, time.Hour, a, k, "")
+			problems := doWork(ctx, scenario.certsProvider, 10, time.Hour, a, k, "")
+
+			if scenario.problems != nil {
+				assert.Len(t, problems.Errors(), len(scenario.problems))
+				for i, problem := range problems.Errors() {
+					assert.EqualError(t, problem, scenario.problems[i])
+				}
+				return
+			}
+
 			if len(problems.Errors()) > 0 {
-				t.Error(problems.Errors())
+				t.Fatalf("expected no problems, got %v", problems.Errors())
+			}
+
+			readFile := func(fileName string) []byte {
+				b, err := os.ReadFile("./testdata/" + scenario.name + "/output/" + fileName)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return b
+			}
+
+			var templates []string
+			templateFiles, err := os.ReadDir("./testdata/" + scenario.name + "/output/templates/")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, file := range templateFiles {
+				templates = append(templates, string(readFile("templates/"+file.Name())))
+			}
+
+			paramFiles, err := os.ReadDir("./testdata/" + scenario.name + "/output/params/")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var params [][]cfTypes.Parameter
+			for _, file := range paramFiles {
+				var content []cfTypes.Parameter
+				err := json.Unmarshal(readFile("params/"+file.Name()), &content)
+				if err != nil {
+					t.Fatal(err)
+				}
+				params = append(params, content)
+			}
+
+			tagFiles, err := os.ReadDir("./testdata/" + scenario.name + "/output/tags/")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var tags [][]cfTypes.Tag
+			for _, file := range tagFiles {
+				var content []cfTypes.Tag
+				err := json.Unmarshal(readFile("tags/"+file.Name()), &content)
+				if err != nil {
+					t.Fatal(err)
+				}
+				tags = append(tags, content)
 			}
 
 			assert.Equal(t, len(clientCF.GetTagCreationHistory()), len(tags))


### PR DESCRIPTION
### Issue Description

As per the existing behavior, once the stack update completes, the
ingress controller immediately updates the status of all ingresses and
routegroups to reference the new load balancer. This update may
sometimes happens before the new load balancer has marked its targets
(skipper-ingress) as healthy, leading clients being routed to a load
balancer that is not ready to serve traffic yet.

### Fix

To improve this behavior we retrieve the ELBs via aws api and build
the models including the ELB state of the corresponding ELB. Then
before updating the ingresses/routegroups (updateIngress func) we
check whether the ELB is in active state, if not we skip updating
the ingresses/routegroups status with the ELB hostname.