### PR TITLE
worker: fail on missing certificates

### DIFF
--- a/aws/acm.go
+++ b/aws/acm.go
@@ -33,7 +33,7 @@ func (p *acmCertificateProvider) GetCertificates(ctx context.Context) ([]*certs.
 	if err != nil {
 		return nil, err
 	}
-	result := make([]*certs.CertificateSummary, 0)
+	result := make([]*certs.CertificateSummary, 0, len(acmSummaries))
 	for _, o := range acmSummaries {
 		summary, err := getCertificateSummaryFromACM(ctx, p.api, o.CertificateArn)
 		if err != nil {

--- a/testdata/no_certificates/input/k8s/ing.yaml
+++ b/testdata/no_certificates/input/k8s/ing.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: no_certificates
+spec:
+  rules:
+  - host: foo.bar.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: foo-bar-service
+            port:
+              name: main-port
+        path: /
+        pathType: ImplementationSpecific

--- a/worker.go
+++ b/worker.go
@@ -304,6 +304,10 @@ func doWork(
 		return problems.Add("failed to get certificates: %w", err)
 	}
 
+	if len(certificateSummaries) == 0 {
+		return problems.Add("no certificates found")
+	}
+
 	cwAlarms, err := getCloudWatchAlarms(kubeAdapter, cwAlarmConfigMapLocation)
 	if err != nil {
 		return problems.Add("failed to retrieve cloudwatch alarm configuration: %w", err)


### PR DESCRIPTION
Controller manages loadbalancer lifecycle based on available certificates.

Prevent controller from deleting loadbalancers when there are no certificates found e.g. due to a bug like #725 or a tag filter misconfiguration (#658).