### PR TITLE
ingress-controller: update ingresses only if the load balancer is active

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ jobs:
     - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     - run: make test
     - run: make lint
+    - run: grep -Ev "zalando-incubator/kube-ingress-aws-controller/(certs|aws)/fake/" profile.cov > tmp.profile.cov
+    - run: mv tmp.profile.cov profile.cov
     - run: goveralls -coverprofile=profile.cov -service=github
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Dockerfile.upstream
 profile.cov
 
 .idea/
+.vscode/

--- a/aws/cf.go
+++ b/aws/cf.go
@@ -24,6 +24,7 @@ type Stack struct {
 	Name              string
 	status            types.StackStatus
 	statusReason      string
+	LoadBalancerARN   string
 	DNSName           string
 	Scheme            string
 	SecurityGroup     string
@@ -105,6 +106,10 @@ func newStackOutput(outputs []types.Output) stackOutput {
 	return result
 }
 
+func (o stackOutput) loadBalancerARN() string {
+	return o[outputLoadBalancerARN]
+}
+
 func (o stackOutput) dnsName() string {
 	return o[outputLoadBalancerDNSName]
 }
@@ -131,6 +136,7 @@ func convertStackParameters(parameters []types.Parameter) map[string]string {
 
 const (
 	// The following constants should be part of the Output section of the CloudFormation template
+	outputLoadBalancerARN     = "LoadBalancerARN"
 	outputLoadBalancerDNSName = "LoadBalancerDNSName"
 	outputTargetGroupARN      = "TargetGroupARN"
 	outputHTTPTargetGroupARN  = "HTTPTargetGroupARN"
@@ -486,6 +492,7 @@ func mapToManagedStack(stack *types.Stack) *Stack {
 
 	return &Stack{
 		Name:              aws.ToString(stack.StackName),
+		LoadBalancerARN:   outputs.loadBalancerARN(),
 		DNSName:           outputs.dnsName(),
 		TargetGroupARNs:   outputs.targetGroupARNs(),
 		Scheme:            parameters[parameterLoadBalancerSchemeParameter],

--- a/aws/cf_template.go
+++ b/aws/cf_template.go
@@ -24,6 +24,10 @@ const (
 	//
 	// [0]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html#cfn-elasticloadbalancingv2-listenerrule-priority
 	internalTrafficDenyRulePriority int64 = 1
+
+	// LoadBalancerResourceLogicalID is the logical ID of the LoadBalancer resource in the CloudFormation template.
+	// Changing this value will recreate the LoadBalancer resource.
+	LoadBalancerResourceLogicalID = "LB"
 )
 
 func hashARNs(certARNs []string) []byte {
@@ -115,9 +119,13 @@ func generateTemplate(spec *stackSpec) (string, error) {
 	const httpsTargetGroupName = "TG"
 
 	template.Outputs = map[string]*cloudformation.Output{
+		outputLoadBalancerARN: {
+			Description: "The ARN of the LoadBalancer",
+			Value:       cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
+		},
 		outputLoadBalancerDNSName: {
 			Description: "DNS name for the LoadBalancer",
-			Value:       cloudformation.GetAtt("LB", "DNSName").String(),
+			Value:       cloudformation.GetAtt(LoadBalancerResourceLogicalID, "DNSName").String(),
 		},
 		outputTargetGroupARN: {
 			Description: "The ARN of the TargetGroup",
@@ -160,7 +168,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 							},
 						},
 					},
-					LoadBalancerArn: cloudformation.Ref("LB").String(),
+					LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 					Port:            cloudformation.Integer(80),
 					Protocol:        cloudformation.String("HTTP"),
 				})
@@ -172,7 +180,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 							TargetGroupArn: cloudformation.Ref(httpTargetGroupName).String(),
 						},
 					},
-					LoadBalancerArn: cloudformation.Ref("LB").String(),
+					LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 					Port:            cloudformation.Integer(80),
 					Protocol:        cloudformation.String("HTTP"),
 				})
@@ -196,7 +204,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 						TargetGroupArn: cloudformation.Ref(httpTargetGroupName).String(),
 					},
 				},
-				LoadBalancerArn: cloudformation.Ref("LB").String(),
+				LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				Port:            cloudformation.Integer(80),
 				Protocol:        cloudformation.String("TCP"),
 			})
@@ -227,7 +235,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 						CertificateArn: cloudformation.String(certificateARNs[0]),
 					},
 				},
-				LoadBalancerArn: cloudformation.Ref("LB").String(),
+				LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				Port:            cloudformation.Integer(443),
 				Protocol:        cloudformation.String("HTTPS"),
 				SslPolicy:       cloudformation.Ref(parameterListenerSslPolicyParameter).String(),
@@ -256,7 +264,7 @@ func generateTemplate(spec *stackSpec) (string, error) {
 						CertificateArn: cloudformation.String(certificateARNs[0]),
 					},
 				},
-				LoadBalancerArn: cloudformation.Ref("LB").String(),
+				LoadBalancerArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				Port:            cloudformation.Integer(443),
 				Protocol:        cloudformation.String("TLS"),
 				SslPolicy:       cloudformation.Ref(parameterListenerSslPolicyParameter).String(),
@@ -379,17 +387,17 @@ func generateTemplate(spec *stackSpec) (string, error) {
 		lb.Type = cloudformation.Ref(parameterLoadBalancerTypeParameter).String()
 	}
 
-	template.AddResource("LB", lb)
+	template.AddResource(LoadBalancerResourceLogicalID, lb)
 
 	if spec.loadbalancerType == LoadBalancerTypeApplication && spec.wafWebAclId != "" {
 		if strings.HasPrefix(spec.wafWebAclId, "arn:aws:wafv2:") {
 			template.AddResource("WAFAssociation", &cloudformation.WAFv2WebACLAssociation{
-				ResourceArn: cloudformation.Ref("LB").String(),
+				ResourceArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				WebACLArn:   cloudformation.Ref(parameterLoadBalancerWAFWebACLIDParameter).String(),
 			})
 		} else {
 			template.AddResource("WAFAssociation", &cloudformation.WAFRegionalWebACLAssociation{
-				ResourceArn: cloudformation.Ref("LB").String(),
+				ResourceArn: cloudformation.Ref(LoadBalancerResourceLogicalID).String(),
 				WebACLID:    cloudformation.Ref(parameterLoadBalancerWAFWebACLIDParameter).String(),
 			})
 		}

--- a/aws/cf_template_test.go
+++ b/aws/cf_template_test.go
@@ -123,7 +123,7 @@ func TestGenerateTemplate(t *testing.T) {
 					&cloudformation.CloudWatchAlarmDimensionList{
 						{
 							Name:  cloudformation.String("LoadBalancer"),
-							Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+							Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 						},
 					},
 					props.Dimensions,
@@ -270,8 +270,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbCrossZone:     true,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[0].Key.Literal, "load_balancing.cross_zone.enabled")
 				require.Equal(t, attributes[0].Value.Literal, "true")
@@ -284,8 +284,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbCrossZone:     false,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[0].Key.Literal, "load_balancing.cross_zone.enabled")
 				require.Equal(t, attributes[0].Value.Literal, "false")
@@ -298,8 +298,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbZoneAffinity:  "any_availability_zone",
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "dns_record.client_routing_policy")
 				require.Equal(t, attributes[1].Value.Literal, "any_availability_zone")
@@ -312,8 +312,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbZoneAffinity:  "availability_zone_affinity",
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "dns_record.client_routing_policy")
 				require.Equal(t, attributes[1].Value.Literal, "availability_zone_affinity")
@@ -326,8 +326,8 @@ func TestGenerateTemplate(t *testing.T) {
 				nlbZoneAffinity:  "partial_availability_zone_affinity",
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "dns_record.client_routing_policy")
 				require.Equal(t, attributes[1].Value.Literal, "partial_availability_zone_affinity")
@@ -352,8 +352,8 @@ func TestGenerateTemplate(t *testing.T) {
 				http2:            true,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "routing.http2.enabled")
 				require.Equal(t, attributes[1].Value.Literal, "true")
@@ -366,8 +366,8 @@ func TestGenerateTemplate(t *testing.T) {
 				http2:            false,
 			},
 			validate: func(t *testing.T, template *cloudformation.Template) {
-				require.NotNil(t, template.Resources["LB"])
-				properties := template.Resources["LB"].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
+				require.NotNil(t, template.Resources[LoadBalancerResourceLogicalID])
+				properties := template.Resources[LoadBalancerResourceLogicalID].Properties.(*cloudformation.ElasticLoadBalancingV2LoadBalancer)
 				attributes := []cloudformation.ElasticLoadBalancingV2LoadBalancerLoadBalancerAttribute(*properties.LoadBalancerAttributes)
 				require.Equal(t, attributes[1].Key.Literal, "routing.http2.enabled")
 				require.Equal(t, attributes[1].Value.Literal, "false")

--- a/aws/cloudwatch.go
+++ b/aws/cloudwatch.go
@@ -77,7 +77,7 @@ func normalizeCloudWatchAlarmDimensions(alarmDimensions *cloudformation.CloudWat
 		return &cloudformation.CloudWatchAlarmDimensionList{
 			{
 				Name:  cloudformation.String("LoadBalancer"),
-				Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+				Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 			},
 		}
 	}
@@ -89,7 +89,7 @@ func normalizeCloudWatchAlarmDimensions(alarmDimensions *cloudformation.CloudWat
 
 		switch dimension.Name.Literal {
 		case "LoadBalancer":
-			value = cloudformation.GetAtt("LB", "LoadBalancerFullName").String()
+			value = cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String()
 		case "TargetGroup":
 			value = cloudformation.GetAtt("TG", "TargetGroupFullName").String()
 		}

--- a/aws/cloudwatch_test.go
+++ b/aws/cloudwatch_test.go
@@ -103,7 +103,7 @@ func TestNormalizeCloudWatchAlarmDimensions(t *testing.T) {
 			expected: &cloudformation.CloudWatchAlarmDimensionList{
 				{
 					Name:  cloudformation.String("LoadBalancer"),
-					Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+					Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 				},
 			},
 		},
@@ -113,7 +113,7 @@ func TestNormalizeCloudWatchAlarmDimensions(t *testing.T) {
 			expected: &cloudformation.CloudWatchAlarmDimensionList{
 				{
 					Name:  cloudformation.String("LoadBalancer"),
-					Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+					Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 				},
 			},
 		},
@@ -135,7 +135,7 @@ func TestNormalizeCloudWatchAlarmDimensions(t *testing.T) {
 			expected: &cloudformation.CloudWatchAlarmDimensionList{
 				{
 					Name:  cloudformation.String("LoadBalancer"),
-					Value: cloudformation.GetAtt("LB", "LoadBalancerFullName").String(),
+					Value: cloudformation.GetAtt(LoadBalancerResourceLogicalID, "LoadBalancerFullName").String(),
 				},
 				{
 					Name:  cloudformation.String("TargetGroup"),

--- a/aws/elbv2.go
+++ b/aws/elbv2.go
@@ -4,17 +4,44 @@ import (
 	"context"
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbv2Types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 )
 
+type LoadBalancerState struct {
+	StateCode elbv2Types.LoadBalancerStateEnum
+	Reason    string
+}
+
+type StackLBState struct {
+	Stack   *Stack
+	LBState *LoadBalancerState
+}
+
 type ELBV2API interface {
 	elbv2.DescribeTargetGroupsAPIClient
 	elbv2.DescribeTargetHealthAPIClient
+	elbv2.DescribeLoadBalancersAPIClient
 	DescribeTags(context.Context, *elbv2.DescribeTagsInput, ...func(*elbv2.Options)) (*elbv2.DescribeTagsOutput, error)
 	RegisterTargets(context.Context, *elbv2.RegisterTargetsInput, ...func(*elbv2.Options)) (*elbv2.RegisterTargetsOutput, error)
 	DeregisterTargets(context.Context, *elbv2.DeregisterTargetsInput, ...func(*elbv2.Options)) (*elbv2.DeregisterTargetsOutput, error)
+}
+
+// IsActiveLBState checks if the LoadBalancerState is in an active state. Return
+// false if the LoadBalancerState is nil.
+func IsActiveLBState(ls *LoadBalancerState) bool {
+	return ls != nil && ls.StateCode == elbv2Types.LoadBalancerStateEnumActive
+}
+
+// GetLBStateString returns a string representation of the LoadBalancerState.
+func GetLBStateString(ls *LoadBalancerState) string {
+	if ls == nil {
+		return "nil"
+	}
+	return string(ls.StateCode)
 }
 
 func registerTargetsOnTargetGroups(ctx context.Context, svc ELBV2API, targetGroupARNs []string, instances []string) error {
@@ -59,4 +86,48 @@ func deregisterTargetsOnTargetGroups(ctx context.Context, svc ELBV2API, targetGr
 		}
 	}
 	return nil
+}
+
+func getLoadBalancerStates(
+	ctx context.Context,
+	svc ELBV2API,
+	loadBalancerARNs []string,
+) (
+	map[string]*LoadBalancerState,
+	error,
+) {
+	loadBalancerStates := make(map[string]*LoadBalancerState, len(loadBalancerARNs))
+
+	if len(loadBalancerARNs) == 0 {
+		return loadBalancerStates, nil
+	}
+
+	// DescribeLoadBalancers API call's loadBalancerArns request parameter can only take 20 items at a time.
+	// https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html
+	const maxLoadBalancerARNsPerRequest = 20
+
+	for i := 0; i < len(loadBalancerARNs); i += maxLoadBalancerARNsPerRequest {
+		end := min(i+maxLoadBalancerARNsPerRequest, len(loadBalancerARNs))
+		chunk := loadBalancerARNs[i:end]
+		input := &elbv2.DescribeLoadBalancersInput{
+			LoadBalancerArns: chunk,
+		}
+		output, err := svc.DescribeLoadBalancers(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("unable to describe load balancers %v: %w", chunk, err)
+		}
+		for _, lb := range output.LoadBalancers {
+			if lb.State == nil {
+				log.Warnf("Loadbalancer %s has no state information", aws.ToString(lb.LoadBalancerArn))
+				loadBalancerStates[aws.ToString(lb.LoadBalancerArn)] = nil
+			} else {
+				loadBalancerStates[aws.ToString(lb.LoadBalancerArn)] = &LoadBalancerState{
+					StateCode: lb.State.Code,
+					Reason:    aws.ToString(lb.State.Reason),
+				}
+			}
+
+		}
+	}
+	return loadBalancerStates, nil
 }

--- a/cloudformation.md
+++ b/cloudformation.md
@@ -51,3 +51,4 @@ The following table describes those outputs:
 |---------------------	|----------------------------------------------------------------------------------	|
 | LoadBalancerDNSName 	| DNS name for the Application Load Balancer created by the stack                  	|
 | TargetGroupARN      	| The ARN of the Target Group created by the stack and referenced by the listeners 	|
+| LoadBalancerARN       | The ARN of the Elastic LoadBalancer that get created by the stack                	|

--- a/testdata/ing_shared_rg_notshared_alb/output/templates/01-ing.cf
+++ b/testdata/ing_shared_rg_notshared_alb/output/templates/01-ing.cf
@@ -200,6 +200,12 @@
         }
     },
     "Outputs": {
+        "LoadBalancerARN": {
+            "Description": "The ARN of the LoadBalancer",
+            "Value": {
+                "Ref": "LB"
+            }
+        },
         "LoadBalancerDNSName": {
             "Description": "DNS name for the LoadBalancer",
             "Value": {

--- a/testdata/ing_shared_rg_notshared_alb/output/templates/02-rg.cf
+++ b/testdata/ing_shared_rg_notshared_alb/output/templates/02-rg.cf
@@ -200,6 +200,12 @@
         }
     },
     "Outputs": {
+        "LoadBalancerARN": {
+            "Description": "The ARN of the LoadBalancer",
+            "Value": {
+                "Ref": "LB"
+            }
+        },
         "LoadBalancerDNSName": {
             "Description": "DNS name for the LoadBalancer",
             "Value": {

--- a/testdata/ingress_alb/output/templates/ing.cf
+++ b/testdata/ingress_alb/output/templates/ing.cf
@@ -200,6 +200,12 @@
         }
     },
     "Outputs": {
+        "LoadBalancerARN": {
+            "Description": "The ARN of the LoadBalancer",
+            "Value": {
+                "Ref": "LB"
+            }
+        },
         "LoadBalancerDNSName": {
             "Description": "DNS name for the LoadBalancer",
             "Value": {

--- a/testdata/ingress_nlb/output/templates/ing.cf
+++ b/testdata/ingress_nlb/output/templates/ing.cf
@@ -176,6 +176,12 @@
         }
     },
     "Outputs": {
+        "LoadBalancerARN": {
+            "Description": "The ARN of the LoadBalancer",
+            "Value": {
+                "Ref": "LB"
+            }
+        },
         "LoadBalancerDNSName": {
             "Description": "DNS name for the LoadBalancer",
             "Value": {

--- a/testdata/ingress_rg_shared_alb/output/templates/shared.cf
+++ b/testdata/ingress_rg_shared_alb/output/templates/shared.cf
@@ -200,6 +200,12 @@
         }
     },
     "Outputs": {
+        "LoadBalancerARN": {
+            "Description": "The ARN of the LoadBalancer",
+            "Value": {
+                "Ref": "LB"
+            }
+        },
         "LoadBalancerDNSName": {
             "Description": "DNS name for the LoadBalancer",
             "Value": {

--- a/testdata/ingress_rg_shared_nlb/output/templates/shared.cf
+++ b/testdata/ingress_rg_shared_nlb/output/templates/shared.cf
@@ -176,6 +176,12 @@
         }
     },
     "Outputs": {
+        "LoadBalancerARN": {
+            "Description": "The ARN of the LoadBalancer",
+            "Value": {
+                "Ref": "LB"
+            }
+        },
         "LoadBalancerDNSName": {
             "Description": "DNS name for the LoadBalancer",
             "Value": {

--- a/testdata/rg_alb/output/templates/rg.cf
+++ b/testdata/rg_alb/output/templates/rg.cf
@@ -200,6 +200,12 @@
         }
     },
     "Outputs": {
+        "LoadBalancerARN": {
+            "Description": "The ARN of the LoadBalancer",
+            "Value": {
+                "Ref": "LB"
+            }
+        },
         "LoadBalancerDNSName": {
             "Description": "DNS name for the LoadBalancer",
             "Value": {

--- a/testdata/rg_nlb/output/templates/rg.cf
+++ b/testdata/rg_nlb/output/templates/rg.cf
@@ -176,6 +176,12 @@
         }
     },
     "Outputs": {
+        "LoadBalancerARN": {
+            "Description": "The ARN of the LoadBalancer",
+            "Value": {
+                "Ref": "LB"
+            }
+        },
         "LoadBalancerDNSName": {
             "Description": "DNS name for the LoadBalancer",
             "Value": {


### PR DESCRIPTION
As per the existing behavior, once the stack update completes, the ingress controller immediately updates the status of all ingresses and routegroups to reference the new load balancer. This update may sometimes happens before the new load balancer has marked its targets (skipper-ingress) as healthy, leading clients being routed to a load balancer that is not ready to serve traffic yet.

To improve this behavior we retrieve the ELBs via AWS API and build the models including the ELB states of the corresponding ELBs. Then before updating the ingresses/routegroups (updateIngress func) we check whether the ELB is in active state, if not we skip updating the ingresses/routegroups status with the ELB hostname.