### PR TITLE
worker: delay ingress status update for new load balancers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,13 @@ clean:
 ## test: runs go test
 test:
 	go test -v -race -coverprofile=profile.cov -cover $(GOPKGS)
-	grep -Ev 'github.com/zalando-incubator/kube-ingress-aws-controller/(certs/fake|aws/fake|internal/aws/cloudformation)/' profile.cov > profile.cov.tmp
+	grep -v \
+		-e github.com/zalando-incubator/kube-ingress-aws-controller/certs/fake/ \
+		-e github.com/zalando-incubator/kube-ingress-aws-controller/aws/fake/ \
+		-e github.com/zalando-incubator/kube-ingress-aws-controller/internal/aws/cloudformation/ \
+		-e github.com/zalando-incubator/kube-ingress-aws-controller/internal/aws/mock/ \
+		-e github.com/zalando-incubator/kube-ingress-aws-controller/internal/kubernetes/mock/ \
+		profile.cov > profile.cov.tmp
 	mv profile.cov.tmp profile.cov
 
 ## lint: runs golangci-lint

--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -684,6 +684,10 @@ func (a *Adapter) GetStackLBStates(ctx context.Context, stacks []*Stack) ([]*Sta
 
 	stackLBStates := make([]*StackLBState, 0, len(stacks))
 	for _, stack := range stacks {
+		if stack.LoadBalancerARN == "" {
+			stackLBStates = append(stackLBStates, &StackLBState{Stack: stack})
+			continue
+		}
 		lbstate, found := lbsMap[stack.LoadBalancerARN]
 		if !found {
 			log.Warnf("The load balancer (ARN: %q) of %q stack is not found", stack.LoadBalancerARN, stack.Name)

--- a/aws/adapter_test.go
+++ b/aws/adapter_test.go
@@ -1074,11 +1074,11 @@ func TestGetStackLBStates(t *testing.T) {
 			expectedStackLBStates: []*StackLBState{
 				{
 					Stack:   &Stack{Name: "stack1", LoadBalancerARN: "arn1"},
-					LBState: &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumActive},
+					LBState: &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumActive},
 				},
 				{
 					Stack:   &Stack{Name: "stack2", LoadBalancerARN: "arn2"},
-					LBState: &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumFailed},
+					LBState: &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumFailed},
 				},
 			},
 			expectError: false,
@@ -1102,7 +1102,7 @@ func TestGetStackLBStates(t *testing.T) {
 			expectedStackLBStates: []*StackLBState{
 				{
 					Stack:   &Stack{Name: "stack1", LoadBalancerARN: "arn1"},
-					LBState: &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumActive},
+					LBState: &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumActive},
 				},
 				{
 					Stack:   &Stack{Name: "stack2", LoadBalancerARN: "arn2"},
@@ -1139,7 +1139,7 @@ func TestGetStackLBStates(t *testing.T) {
 			expectedStackLBStates: []*StackLBState{
 				{
 					Stack:   &Stack{Name: "stack1", LoadBalancerARN: "arn1"},
-					LBState: &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumActive},
+					LBState: &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumActive},
 				},
 				{
 					Stack:   &Stack{Name: "stack2"},
@@ -1170,7 +1170,7 @@ func TestGetStackLBStates(t *testing.T) {
 					if expected.LBState == nil {
 						require.Nil(t, stackLBStates[i].LBState)
 					} else {
-						require.Equal(t, expected.LBState.StateCode, stackLBStates[i].LBState.StateCode)
+						require.Equal(t, expected.LBState.stateCode, stackLBStates[i].LBState.stateCode)
 					}
 				}
 			}

--- a/aws/elbv2_test.go
+++ b/aws/elbv2_test.go
@@ -34,16 +34,15 @@ func TestIsActiveLBState(t *testing.T) {
 		expected bool
 	}{
 		{"nil state", nil, false},
-		{"active state", &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumActive}, true},
-		{"provisioning state", &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumProvisioning}, false},
-		{"active impaired state", &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumActiveImpaired}, false},
-		{"provisioning state", &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumFailed}, false},
+		{"active state", &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumActive}, true},
+		{"provisioning state", &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumProvisioning}, false},
+		{"active impaired state", &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumActiveImpaired}, false},
+		{"provisioning state", &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumFailed}, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsActiveLBState(tt.lbState)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, tt.lbState.IsActive())
 		})
 	}
 }
@@ -55,16 +54,15 @@ func TestGetLBStateString(t *testing.T) {
 		expected string
 	}{
 		{"nil state", nil, "nil"},
-		{"active state", &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumActive}, "active"},
-		{"provisioning state", &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumProvisioning}, "provisioning"},
-		{"active impaired state", &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumActiveImpaired}, "active_impaired"},
-		{"failed state", &LoadBalancerState{StateCode: elbv2Types.LoadBalancerStateEnumFailed}, "failed"},
+		{"active state", &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumActive}, "active"},
+		{"provisioning state", &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumProvisioning}, "provisioning"},
+		{"active impaired state", &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumActiveImpaired}, "active_impaired"},
+		{"failed state", &LoadBalancerState{stateCode: elbv2Types.LoadBalancerStateEnumFailed}, "failed"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GetLBStateString(tt.lbState)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, tt.lbState.StateCodeString())
 		})
 	}
 }
@@ -258,8 +256,8 @@ func TestDeregisterTargetsOnTargetGroups(t *testing.T) {
 func TestGetLoadBalancerStates(t *testing.T) {
 	outputBasedOnInput := fake.ELBv2Outputs{DescribeLoadBalancers: nil}
 	expectedLBState := LoadBalancerState{
-		StateCode: elbv2Types.LoadBalancerStateEnumActive,
-		Reason:    "Mocked state",
+		stateCode: elbv2Types.LoadBalancerStateEnumActive,
+		reason:    "Mocked state",
 	}
 
 	for _, test := range []struct {

--- a/certs/fake/certificate.go
+++ b/certs/fake/certificate.go
@@ -88,9 +88,7 @@ func NewCA() (*CA, error) {
 	return ca, nil
 }
 
-func (ca *CA) NewCertificateSummary() (*certs.CertificateSummary, error) {
-	altNames := []string{"foo.bar.org"}
-	arn := "DUMMY"
+func (ca *CA) NewCertificateSummary(arn string, altNames ...string) (*certs.CertificateSummary, error) {
 	notBefore := time.Now()
 	notAfter := time.Now().Add(time.Hour * 24)
 

--- a/controller.go
+++ b/controller.go
@@ -425,7 +425,7 @@ func main() {
 
 	w := &worker{
 		awsAdapter:         awsAdapter,
-		kubeAdapter:        kubeAdapter,
+		kubeAPI:            kubeAdapter,
 		metrics:            metrics,
 		certsProvider:      certificatesProvider,
 		certsPerALB:        certificatesPerALB,

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,7 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/aws/mock/mock.go
+++ b/internal/aws/mock/mock.go
@@ -1,0 +1,136 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/zalando-incubator/kube-ingress-aws-controller/aws"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// AutoScalingAPI is a mock implementation of [aws.AutoScalingAPI]
+type AutoScalingAPI struct {
+	mock.Mock
+}
+
+var _ aws.AutoScalingAPI = &AutoScalingAPI{}
+
+func (m *AutoScalingAPI) DescribeAutoScalingGroups(ctx context.Context, params *autoscaling.DescribeAutoScalingGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*autoscaling.DescribeAutoScalingGroupsOutput), args.Error(1)
+}
+
+func (m *AutoScalingAPI) DescribeLoadBalancerTargetGroups(ctx context.Context, params *autoscaling.DescribeLoadBalancerTargetGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeLoadBalancerTargetGroupsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*autoscaling.DescribeLoadBalancerTargetGroupsOutput), args.Error(1)
+}
+
+func (m *AutoScalingAPI) AttachLoadBalancerTargetGroups(ctx context.Context, params *autoscaling.AttachLoadBalancerTargetGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.AttachLoadBalancerTargetGroupsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*autoscaling.AttachLoadBalancerTargetGroupsOutput), args.Error(1)
+}
+
+func (m *AutoScalingAPI) DetachLoadBalancerTargetGroups(ctx context.Context, params *autoscaling.DetachLoadBalancerTargetGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DetachLoadBalancerTargetGroupsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*autoscaling.DetachLoadBalancerTargetGroupsOutput), args.Error(1)
+}
+
+// CloudFormationAPI is a mock implementation of [aws.CloudFormationAPI]
+type CloudFormationAPI struct {
+	mock.Mock
+}
+
+var _ aws.CloudFormationAPI = &CloudFormationAPI{}
+
+func (m *CloudFormationAPI) DescribeStacks(ctx context.Context, params *cloudformation.DescribeStacksInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*cloudformation.DescribeStacksOutput), args.Error(1)
+}
+
+func (m *CloudFormationAPI) CreateStack(ctx context.Context, params *cloudformation.CreateStackInput, optFns ...func(*cloudformation.Options)) (*cloudformation.CreateStackOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*cloudformation.CreateStackOutput), args.Error(1)
+}
+
+func (m *CloudFormationAPI) UpdateTerminationProtection(ctx context.Context, params *cloudformation.UpdateTerminationProtectionInput, optFns ...func(*cloudformation.Options)) (*cloudformation.UpdateTerminationProtectionOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*cloudformation.UpdateTerminationProtectionOutput), args.Error(1)
+}
+
+func (m *CloudFormationAPI) UpdateStack(ctx context.Context, params *cloudformation.UpdateStackInput, optFns ...func(*cloudformation.Options)) (*cloudformation.UpdateStackOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*cloudformation.UpdateStackOutput), args.Error(1)
+}
+
+func (m *CloudFormationAPI) DeleteStack(ctx context.Context, params *cloudformation.DeleteStackInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DeleteStackOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*cloudformation.DeleteStackOutput), args.Error(1)
+}
+
+// EC2API is a mock implementation of [aws.EC2API]
+type EC2API struct {
+	mock.Mock
+}
+
+var _ aws.EC2API = &EC2API{}
+
+func (m *EC2API) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*ec2.DescribeInstancesOutput), args.Error(1)
+}
+
+func (m *EC2API) DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*ec2.DescribeSubnetsOutput), args.Error(1)
+}
+
+func (m *EC2API) DescribeRouteTables(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*ec2.DescribeRouteTablesOutput), args.Error(1)
+}
+
+func (m *EC2API) DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*ec2.DescribeSecurityGroupsOutput), args.Error(1)
+}
+
+// ELBV2API is a mock implementation of [aws.ELBV2API]
+type ELBV2API struct {
+	mock.Mock
+}
+
+var _ aws.ELBV2API = &ELBV2API{}
+
+func (m *ELBV2API) DescribeTargetGroups(ctx context.Context, params *elbv2.DescribeTargetGroupsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetGroupsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*elbv2.DescribeTargetGroupsOutput), args.Error(1)
+}
+
+func (m *ELBV2API) DescribeTargetHealth(ctx context.Context, params *elbv2.DescribeTargetHealthInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetHealthOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*elbv2.DescribeTargetHealthOutput), args.Error(1)
+}
+
+func (m *ELBV2API) DescribeLoadBalancers(ctx context.Context, params *elbv2.DescribeLoadBalancersInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeLoadBalancersOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*elbv2.DescribeLoadBalancersOutput), args.Error(1)
+}
+
+func (m *ELBV2API) DescribeTags(ctx context.Context, params *elbv2.DescribeTagsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTagsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*elbv2.DescribeTagsOutput), args.Error(1)
+}
+
+func (m *ELBV2API) RegisterTargets(ctx context.Context, params *elbv2.RegisterTargetsInput, optFns ...func(*elbv2.Options)) (*elbv2.RegisterTargetsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*elbv2.RegisterTargetsOutput), args.Error(1)
+}
+
+func (m *ELBV2API) DeregisterTargets(ctx context.Context, params *elbv2.DeregisterTargetsInput, optFns ...func(*elbv2.Options)) (*elbv2.DeregisterTargetsOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*elbv2.DeregisterTargetsOutput), args.Error(1)
+}

--- a/internal/kubernetes/mock/mock.go
+++ b/internal/kubernetes/mock/mock.go
@@ -1,0 +1,29 @@
+package mock
+
+import (
+	"github.com/zalando-incubator/kube-ingress-aws-controller/kubernetes"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// API is a mock implementation of [kubernetes.API]
+type API struct {
+	mock.Mock
+}
+
+var _ kubernetes.API = (*API)(nil)
+
+func (m *API) ListResources() ([]*kubernetes.Ingress, error) {
+	args := m.Called()
+	return args.Get(0).([]*kubernetes.Ingress), args.Error(1)
+}
+
+func (m *API) UpdateIngressLoadBalancer(ingress *kubernetes.Ingress, loadBalancerDNSName string) error {
+	args := m.Called(ingress, loadBalancerDNSName)
+	return args.Error(0)
+}
+
+func (m *API) GetConfigMap(namespace, name string) (*kubernetes.ConfigMap, error) {
+	args := m.Called(namespace, name)
+	return args.Get(0).(*kubernetes.ConfigMap), args.Error(1)
+}

--- a/kubernetes/adapter.go
+++ b/kubernetes/adapter.go
@@ -11,6 +11,21 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+type API interface {
+	// ListResources can be used to obtain the list of ingress and routegroup
+	// resources for all namespaces filtered by class. It
+	// returns the Ingress business object, that for the controller does
+	// not matter to be routegroup or ingress.
+	ListResources() ([]*Ingress, error)
+
+	// UpdateIngressLoadBalancer can be used to update the loadBalancer object of an ingress resource. It will update
+	// the hostname property with the provided load balancer DNS name.
+	UpdateIngressLoadBalancer(ingress *Ingress, loadBalancerDNSName string) error
+
+	// GetConfigMap retrieves the ConfigMap with name from namespace.
+	GetConfigMap(namespace, name string) (*ConfigMap, error)
+}
+
 type Adapter struct {
 	kubeClient                     client
 	clientset                      kubernetes.Interface
@@ -24,6 +39,8 @@ type Adapter struct {
 	clusterLocalDomain             string
 	routeGroupSupport              bool
 }
+
+var _ API = &Adapter{}
 
 type IngressType string
 

--- a/minloadbalancerage_test.go
+++ b/minloadbalancerage_test.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	asgtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+
+	"github.com/zalando-incubator/kube-ingress-aws-controller/aws"
+	"github.com/zalando-incubator/kube-ingress-aws-controller/certs"
+	"github.com/zalando-incubator/kube-ingress-aws-controller/kubernetes"
+
+	certsfake "github.com/zalando-incubator/kube-ingress-aws-controller/certs/fake"
+	awsmock "github.com/zalando-incubator/kube-ingress-aws-controller/internal/aws/mock"
+	kubemock "github.com/zalando-incubator/kube-ingress-aws-controller/internal/kubernetes/mock"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type MinLoadBalancerAgeTestSuite struct {
+	suite.Suite
+
+	worker      *worker
+	clientELBv2 *awsmock.ELBV2API
+	kubeAPI     *kubemock.API
+}
+
+func TestMinLoadBalancerAge(t *testing.T) {
+	suite.Run(t, new(MinLoadBalancerAgeTestSuite))
+}
+
+func (suite *MinLoadBalancerAgeTestSuite) SetupTest() {
+	t := suite.T()
+
+	const minLoadBalancerAge = 6 * time.Minute
+
+	// AWS mocks setup
+	clientASG := &awsmock.AutoScalingAPI{}
+	clientEC2 := &awsmock.EC2API{}
+	clientELBv2 := &awsmock.ELBV2API{}
+	clientCF := &awsmock.CloudFormationAPI{}
+
+	ca, err := certsfake.NewCA()
+	require.NoError(t, err)
+
+	certSummary, err := ca.NewCertificateSummary("arn:test-cert-1", "ingress-1.test")
+	require.NoError(t, err)
+
+	certsProvider := &certsfake.CertificateProvider{
+		Summaries: []*certs.CertificateSummary{certSummary},
+	}
+
+	// Mock setup for EC2
+	clientEC2.On("DescribeSecurityGroups", mock.Anything, mock.Anything, mock.Anything).
+		Return(&ec2.DescribeSecurityGroupsOutput{
+			SecurityGroups: []ec2types.SecurityGroup{
+				{
+					GroupId:   awssdk.String("sg-12345678"),
+					GroupName: awssdk.String("test-sg"),
+				},
+			},
+		}, nil)
+
+	clientEC2.On("DescribeSubnets", mock.Anything, mock.Anything, mock.Anything).
+		Return(&ec2.DescribeSubnetsOutput{
+			Subnets: []ec2types.Subnet{
+				{
+					SubnetId:         awssdk.String("subnet-12345678"),
+					AvailabilityZone: awssdk.String("eu-central-1a"),
+					Tags: []ec2types.Tag{
+						{
+							Key:   awssdk.String("kubernetes.io/cluster/aws:cluster-1"),
+							Value: awssdk.String("owned"),
+						},
+					},
+				},
+			},
+		}, nil)
+
+	clientEC2.On("DescribeRouteTables", mock.Anything, mock.Anything, mock.Anything).
+		Return(&ec2.DescribeRouteTablesOutput{
+			RouteTables: []ec2types.RouteTable{
+				{
+					RouteTableId: awssdk.String("rtb-12345678"),
+					Associations: []ec2types.RouteTableAssociation{
+						{
+							SubnetId: awssdk.String("subnet-12345678"),
+						},
+					},
+				},
+			},
+		}, nil)
+
+	clientCF.On("DescribeStacks", mock.Anything, mock.Anything, mock.Anything).
+		Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []cftypes.Stack{
+				{
+					StackName:   awssdk.String("kube-ing-1"),
+					StackStatus: cftypes.StackStatusCreateComplete,
+					Tags: []cftypes.Tag{
+						{
+							Key:   awssdk.String("kubernetes.io/cluster/aws:cluster-1"),
+							Value: awssdk.String("owned"),
+						},
+						{
+							Key:   awssdk.String("ingress:certificate-arn/arn:test-cert-1"),
+							Value: awssdk.String("0001-01-01T00:00:00Z"),
+						},
+					},
+					Parameters: []cftypes.Parameter{
+						{
+							ParameterKey:   awssdk.String("LoadBalancerSecurityGroupParameter"),
+							ParameterValue: awssdk.String("sg-12345678"),
+						},
+						{
+							ParameterKey:   awssdk.String("IpAddressType"),
+							ParameterValue: awssdk.String("ipv4"),
+						},
+						{
+							ParameterKey:   awssdk.String("LoadBalancerSchemeParameter"),
+							ParameterValue: awssdk.String("internet-facing"),
+						},
+						{
+							ParameterKey:   awssdk.String("Type"),
+							ParameterValue: awssdk.String(aws.LoadBalancerTypeNetwork),
+						},
+						{
+							ParameterKey:   awssdk.String("HTTP2"),
+							ParameterValue: awssdk.String("true"),
+						},
+						{
+							ParameterKey:   awssdk.String("ListenerSslPolicyParameter"),
+							ParameterValue: awssdk.String(aws.DefaultSslPolicy),
+						},
+					},
+					Outputs: []cftypes.Output{
+						{
+							OutputKey:   awssdk.String("LoadBalancerDNSName"),
+							OutputValue: awssdk.String("test-lb-1.amazonaws.com"),
+						},
+						{
+							OutputKey:   awssdk.String("LoadBalancerARN"),
+							OutputValue: awssdk.String("arn:test-lb-1"),
+						},
+					},
+				},
+			},
+		}, nil)
+
+	clientEC2.On("DescribeInstances", mock.Anything, mock.Anything, mock.Anything).
+		Return(&ec2.DescribeInstancesOutput{
+			Reservations: []ec2types.Reservation{},
+		}, nil)
+
+	clientASG.On("DescribeAutoScalingGroups", mock.Anything, mock.Anything, mock.Anything).
+		Return(&autoscaling.DescribeAutoScalingGroupsOutput{
+			AutoScalingGroups: []asgtypes.AutoScalingGroup{
+				{
+					AutoScalingGroupName:    awssdk.String("kube-ing-1"),
+					LaunchConfigurationName: awssdk.String("kube-ing-1-launch-config"),
+					MinSize:                 awssdk.Int32(1),
+					MaxSize:                 awssdk.Int32(3),
+					DesiredCapacity:         awssdk.Int32(2),
+					AvailabilityZones:       []string{"eu-central-1a"},
+					Tags: []asgtypes.TagDescription{
+						{
+							Key:   awssdk.String("kubernetes.io/cluster/aws:cluster-1"),
+							Value: awssdk.String("owned"),
+						},
+					},
+				},
+			},
+		}, nil)
+
+	clientASG.On("DescribeLoadBalancerTargetGroups", mock.Anything, mock.Anything, mock.Anything).
+		Return(&autoscaling.DescribeLoadBalancerTargetGroupsOutput{
+			LoadBalancerTargetGroups: []asgtypes.LoadBalancerTargetGroupState{
+				{
+					LoadBalancerTargetGroupARN: awssdk.String("arn:tg-1"),
+					State:                      awssdk.String("InService"),
+				},
+			},
+		}, nil)
+
+	clientELBv2.On("DescribeTargetGroups", mock.Anything, &elbv2.DescribeTargetGroupsInput{}, mock.Anything).
+		Return(&elbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{
+					TargetGroupArn: awssdk.String("arn:tg-1"),
+					Protocol:       elbv2types.ProtocolEnumTcp,
+					Port:           awssdk.Int32(80),
+					VpcId:          awssdk.String("vpc-1"),
+				},
+			},
+		}, nil)
+
+	clientELBv2.On("DescribeTags", mock.Anything, &elbv2.DescribeTagsInput{ResourceArns: []string{"arn:tg-1"}}, mock.Anything).
+		Return(&elbv2.DescribeTagsOutput{}, nil)
+
+	a := &aws.Adapter{
+		TargetCNI: &aws.TargetCNIconfig{Enabled: false},
+	}
+	a = a.WithCustomAutoScalingClient(clientASG).
+		WithCustomEc2Client(clientEC2).
+		WithCustomElbv2Client(clientELBv2).
+		WithCustomCloudFormationClient(clientCF).
+		WithNLBZoneAffinity(aws.DefaultZoneAffinity)
+
+	a, err = a.UpdateManifest(context.Background(), "aws:cluster-1", "vpc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Kubernetes mocks setup
+	kubeAPI := &kubemock.API{}
+
+	// Set up mock expectations for kubeAPI
+	kubeAPI.On("ListResources").Return([]*kubernetes.Ingress{
+		{
+			ResourceType:     kubernetes.TypeIngress,
+			Name:             "ingress-1",
+			Namespace:        "default",
+			Shared:           true,
+			HTTP2:            true,
+			ClusterLocal:     false,
+			SSLPolicy:        aws.DefaultSslPolicy,
+			IPAddressType:    aws.IPAddressTypeIPV4,
+			SecurityGroup:    "sg-12345678",
+			LoadBalancerType: aws.LoadBalancerTypeNetwork,
+			Scheme:           string(elbv2types.LoadBalancerSchemeEnumInternetFacing),
+			Hostnames:        []string{"ingress-1.test"},
+		},
+	}, nil)
+
+	kubeAPI.On("UpdateIngressLoadBalancer", mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+
+	// Worker setup
+	firstRun = false
+	t.Cleanup(func() { firstRun = true })
+
+	suite.worker = &worker{
+		awsAdapter:         a,
+		kubeAPI:            kubeAPI,
+		metrics:            newMetrics(),
+		certsProvider:      certsProvider,
+		certsPerALB:        10,
+		certTTL:            1 * time.Hour,
+		minLoadBalancerAge: minLoadBalancerAge,
+	}
+	suite.clientELBv2 = clientELBv2
+	suite.kubeAPI = kubeAPI
+}
+
+func (suite *MinLoadBalancerAgeTestSuite) TestYoungLoadBalancer() {
+	suite.clientELBv2.On("DescribeLoadBalancers", mock.Anything, mock.Anything, mock.Anything).
+		Return(&elbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{
+					LoadBalancerArn: awssdk.String("arn:test-lb-1"),
+					Scheme:          elbv2types.LoadBalancerSchemeEnumInternetFacing,
+					Type:            elbv2types.LoadBalancerTypeEnumNetwork,
+					State:           &elbv2types.LoadBalancerState{Code: elbv2types.LoadBalancerStateEnumActive},
+					CreatedTime:     awssdk.Time(time.Now().Add(-2 * time.Minute)),
+				},
+			},
+		}, nil)
+
+	problems := suite.worker.doWork(context.Background())
+
+	suite.Empty(problems.Errors())
+
+	suite.kubeAPI.AssertNotCalled(suite.T(), "UpdateIngressLoadBalancer", mock.Anything, mock.Anything)
+}
+
+func (suite *MinLoadBalancerAgeTestSuite) TestOldBalancer() {
+	suite.clientELBv2.On("DescribeLoadBalancers", mock.Anything, mock.Anything, mock.Anything).
+		Return(&elbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{
+					LoadBalancerArn: awssdk.String("arn:test-lb-1"),
+					Scheme:          elbv2types.LoadBalancerSchemeEnumInternetFacing,
+					Type:            elbv2types.LoadBalancerTypeEnumNetwork,
+					State:           &elbv2types.LoadBalancerState{Code: elbv2types.LoadBalancerStateEnumActive},
+					CreatedTime:     awssdk.Time(time.Now().Add(-7 * time.Minute)),
+				},
+			},
+		}, nil)
+
+	problems := suite.worker.doWork(context.Background())
+
+	suite.Empty(problems.Errors())
+
+	ingressMatcher := mock.MatchedBy(func(ingress *kubernetes.Ingress) bool {
+		return ingress.Namespace == "default" && ingress.Name == "ingress-1"
+	})
+	suite.kubeAPI.AssertCalled(suite.T(), "UpdateIngressLoadBalancer", ingressMatcher, "test-lb-1.amazonaws.com")
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -41,7 +41,7 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 	ca, err := certsfake.NewCA()
 	require.NoError(tt, err)
 
-	certSummary, err := ca.NewCertificateSummary()
+	certSummary, err := ca.NewCertificateSummary("DUMMY", "foo.bar.org")
 	require.NoError(tt, err)
 
 	var certsProvider certs.CertificatesProvider = &certsfake.CertificateProvider{
@@ -478,7 +478,7 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 
 			w := &worker{
 				awsAdapter:    a,
-				kubeAdapter:   k,
+				kubeAPI:       k,
 				metrics:       newMetrics(),
 				certsProvider: scenario.certsProvider,
 				certsPerALB:   10,

--- a/worker_test.go
+++ b/worker_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	autoScalingTypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	cfTypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
-	elbv2Types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -923,10 +922,7 @@ func TestCertificateExists(tt *testing.T) {
 func TestGetAllLoadBalancers(tt *testing.T) {
 	certTTL, _ := time.ParseDuration("90d")
 
-	activeLBState := &aws.LoadBalancerState{
-		StateCode: elbv2Types.LoadBalancerStateEnumActive,
-		Reason:    "",
-	}
+	aLBState := &aws.LoadBalancerState{}
 
 	for _, test := range []struct {
 		name          string
@@ -942,7 +938,7 @@ func TestGetAllLoadBalancers(tt *testing.T) {
 						Scheme:        "foo",
 						SecurityGroup: "sg-123456",
 					},
-					LBState: activeLBState,
+					LBState: aLBState,
 				},
 			},
 			certs: []*certs.CertificateSummary{},
@@ -954,7 +950,7 @@ func TestGetAllLoadBalancers(tt *testing.T) {
 					shared:                       true,
 					ingresses:                    map[string][]*kubernetes.Ingress{},
 					certTTL:                      certTTL,
-					state:                        activeLBState,
+					state:                        aLBState,
 				},
 			},
 		},
@@ -969,7 +965,7 @@ func TestGetAllLoadBalancers(tt *testing.T) {
 							"cert-arn": {},
 						},
 					},
-					LBState: activeLBState,
+					LBState: aLBState,
 				},
 			},
 			certs: []*certs.CertificateSummary{
@@ -991,7 +987,7 @@ func TestGetAllLoadBalancers(tt *testing.T) {
 						"cert-arn": {},
 					},
 					certTTL: certTTL,
-					state:   activeLBState,
+					state:   aLBState,
 				},
 			},
 		},
@@ -1006,7 +1002,7 @@ func TestGetAllLoadBalancers(tt *testing.T) {
 							"cert-arn": {},
 						},
 					},
-					LBState: activeLBState,
+					LBState: aLBState,
 				},
 			},
 			certs: []*certs.CertificateSummary{},
@@ -1018,7 +1014,7 @@ func TestGetAllLoadBalancers(tt *testing.T) {
 					shared:                       true,
 					ingresses:                    map[string][]*kubernetes.Ingress{},
 					certTTL:                      certTTL,
-					state:                        activeLBState,
+					state:                        aLBState,
 				},
 			},
 		},


### PR DESCRIPTION
Within https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/748 the controller was improved to wait until loadbalancer state becomes "active" before updating ingress status which triggers traffic switch to the new loadbalancer (e.g. via external-dns).

It turns out that while new loadbalancer state is active its target groups may not have discovered targets yet.

This change delays ingress status update for a new loadbalancer to give its target groups time to discover targets. The delay is configured by a new `min-loadbalancer-age` flag. Default value was chosen after testing in an AWS account.

The more elaborate alternative is to call `describe-target-health` and check `TargetHealthDescriptions`.

Other changes:

* unexport loadbalancer state fields
* make loadbalancer state accessors its members
* skip logging of empty loadbalancer ARNs in GetStackLBStates
* use structured logging in updateIngress
* introduce AWS and Kubernetes API internal mocks using github.com/stretchr/testify/mock