### PR TITLE
aws: sort subnets in Adapter.FindLBSubnets

### DIFF
--- a/aws/adapter.go
+++ b/aws/adapter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -976,7 +977,7 @@ func buildManifest(ctx context.Context, awsAdapter *Adapter, clusterID, vpcID st
 	}, nil
 }
 
-// FindLBSubnets finds subnets for an ALB based on the scheme.
+// FindLBSubnets finds subnets for a load balancer based on the scheme.
 //
 // It follows the same logic for finding subnets as the kube-controller-manager
 // when finding subnets for ELBs used for services of type LoadBalancer.
@@ -1029,6 +1030,9 @@ func (a *Adapter) FindLBSubnets(scheme string) []string {
 	for _, subnet := range subnetsByAZ {
 		subnetIDs = append(subnetIDs, subnet.id)
 	}
+
+	// Sort to have a stable order
+	sort.Strings(subnetIDs)
 
 	return subnetIDs
 }

--- a/aws/adapter_test.go
+++ b/aws/adapter_test.go
@@ -679,6 +679,23 @@ func TestFindLBSubnets(tt *testing.T) {
 			expectedSubnets: []string{"1", "2"},
 		},
 		{
+			name: "should find two public subnets for public LB regardless of details order",
+			subnets: []*subnetDetails{
+				{
+					availabilityZone: "b",
+					public:           true,
+					id:               "2",
+				},
+				{
+					availabilityZone: "a",
+					public:           true,
+					id:               "1",
+				},
+			},
+			scheme:          string(elbv2Types.LoadBalancerSchemeEnumInternetFacing),
+			expectedSubnets: []string{"1", "2"},
+		},
+		{
 			name: "should select first lexicographically subnet when two match a single zone",
 			subnets: []*subnetDetails{
 				{
@@ -760,9 +777,6 @@ func TestFindLBSubnets(tt *testing.T) {
 			if len(subnets) != len(test.expectedSubnets) {
 				t.Errorf("unexpected number of subnets %d, expected %d", len(subnets), len(test.expectedSubnets))
 			}
-
-			// sort subnets so it's simpler to compare.
-			sort.Strings(subnets)
 
 			for i, subnet := range subnets {
 				if subnet != test.expectedSubnets[i] {


### PR DESCRIPTION
Adapter.FindLBSubnets method is used to specify stack subnets and becomes a parameter of a CloudFormation template.

This change returns sorted result to avoid sporadic changes to CloudFormation template that triggers update of CloudFormation stack and corresponding LoadBalancer Subnets.

Though LoadBalancer Subnets update does not require interruption as per https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-subnets there is no reason to trigger any unneccessary updates.

Related to https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/454