### PR TITLE
Add worker type

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -91,10 +91,6 @@ var (
 	defaultInternalDomains        = fmt.Sprintf("*%s", kubernetes.DefaultClusterLocalDomain)
 )
 
-func init() {
-	registerMetrics()
-}
-
 func loadSettings() error {
 	kingpin.Flag("version", "Print version and exit").Default("false").BoolVar(&versionFlag)
 	kingpin.Flag("debug", "Enables debug logging level").Default("false").BoolVar(&debugFlag)
@@ -417,21 +413,26 @@ func main() {
 	log.Infof("NLB Cross Zone: %t", nlbCrossZone)
 	log.Infof("NLB Zone Affinity: %s", nlbZoneAffinity)
 
+	metrics := newMetrics()
+
 	go handleTerminationSignals(cancel, syscall.SIGTERM, syscall.SIGQUIT)
-	go serveMetrics(metricsAddress)
+	go metrics.serve(metricsAddress)
 	if awsAdapter.TargetCNI.Enabled {
 		go cniEventHandler(ctx, awsAdapter.TargetCNI, awsAdapter.SetTargetsOnCNITargetGroups, kubeAdapter.PodInformer)
 	}
-	startPolling(
-		ctx,
-		certificatesProvider,
-		certificatesPerALB,
-		certTTL,
-		awsAdapter,
-		kubeAdapter,
-		pollingInterval,
-		wafWebAclId,
-	)
+
+	w := &worker{
+		awsAdapter:    awsAdapter,
+		kubeAdapter:   kubeAdapter,
+		metrics:       metrics,
+		certsProvider: certificatesProvider,
+		certsPerALB:   certificatesPerALB,
+		certTTL:       certTTL,
+		globalWAFACL:  wafWebAclId,
+		cwAlarmConfig: cwAlarmConfigMapLocation,
+	}
+
+	w.startPolling(ctx, pollingInterval)
 
 	log.Infof("Terminating %s", os.Args[0])
 }

--- a/metrics.go
+++ b/metrics.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var metrics = struct {
+type metrics struct {
 	lastSyncTimestamp              prometheus.Gauge
 	ingressesTotal                 prometheus.Gauge
 	routegroupsTotal               prometheus.Gauge
@@ -20,96 +20,100 @@ var metrics = struct {
 	certificatesTotal              prometheus.Gauge
 	cloudWatchAlarmsTotal          prometheus.Gauge
 	changesTotal                   changeCounter
-}{
-	lastSyncTimestamp: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "last_sync_timestamp_seconds",
-			Help:      "Timestamp of the last successful controller reconciliation run",
-		},
-	),
-	ingressesTotal: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "ingresses_total",
-			Help:      "Number of managed Kubernetes Ingresses",
-		},
-	),
-	routegroupsTotal: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "routegroups_total",
-			Help:      "Number of managed Route Groups",
-		},
-	),
-	stacksTotal: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "stacks_total",
-			Help:      "Number of managed Cloud Formation stacks",
-		},
-	),
-	ownedAutoscalingGroupsTotal: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "owned_autoscaling_groups_total",
-			Help:      "Number of owned Autoscaling Groups",
-		},
-	),
-	targetedAutoscalingGroupsTotal: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "targeted_autoscaling_groups_total",
-			Help:      "Number of targeted Autoscaling Groups",
-		},
-	),
-	instancesTotal: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "instances_total",
-			Help:      "Number of managed EC2 instances",
-		},
-	),
-	standaloneInstancesTotal: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "standalone_instances_total",
-			Help:      "Number of managed EC2 instances not in the Autoscaling Group",
-		},
-	),
-	certificatesTotal: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "certificates_total",
-			Help:      "Number of certificates",
-		},
-	),
-	cloudWatchAlarmsTotal: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "cloud_watch_alarms_total",
-			Help:      "Number of Cloud Watch Alarms",
-		},
-	),
-	changesTotal: changeCounter{prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "kube_ingress_aws",
-			Subsystem: "controller",
-			Name:      "changes_total",
-			Help:      "Number of Cloud Formation stack, Kubernetes Ingress and Route Group changes",
-		},
-		[]string{"resource_type", "operation"},
-	)},
+}
+
+func newMetrics() *metrics {
+	return &metrics{
+		lastSyncTimestamp: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "last_sync_timestamp_seconds",
+				Help:      "Timestamp of the last successful controller reconciliation run",
+			},
+		),
+		ingressesTotal: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "ingresses_total",
+				Help:      "Number of managed Kubernetes Ingresses",
+			},
+		),
+		routegroupsTotal: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "routegroups_total",
+				Help:      "Number of managed Route Groups",
+			},
+		),
+		stacksTotal: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "stacks_total",
+				Help:      "Number of managed Cloud Formation stacks",
+			},
+		),
+		ownedAutoscalingGroupsTotal: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "owned_autoscaling_groups_total",
+				Help:      "Number of owned Autoscaling Groups",
+			},
+		),
+		targetedAutoscalingGroupsTotal: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "targeted_autoscaling_groups_total",
+				Help:      "Number of targeted Autoscaling Groups",
+			},
+		),
+		instancesTotal: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "instances_total",
+				Help:      "Number of managed EC2 instances",
+			},
+		),
+		standaloneInstancesTotal: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "standalone_instances_total",
+				Help:      "Number of managed EC2 instances not in the Autoscaling Group",
+			},
+		),
+		certificatesTotal: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "certificates_total",
+				Help:      "Number of certificates",
+			},
+		),
+		cloudWatchAlarmsTotal: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "cloud_watch_alarms_total",
+				Help:      "Number of Cloud Watch Alarms",
+			},
+		),
+		changesTotal: changeCounter{prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "kube_ingress_aws",
+				Subsystem: "controller",
+				Name:      "changes_total",
+				Help:      "Number of Cloud Formation stack, Kubernetes Ingress and Route Group changes",
+			},
+			[]string{"resource_type", "operation"},
+		)},
+	}
 }
 
 type changeCounter struct {
@@ -128,7 +132,7 @@ func (c changeCounter) deleted(resourceType string) {
 	c.WithLabelValues(resourceType, "delete").Inc()
 }
 
-func registerMetrics() {
+func (metrics *metrics) serve(address string) {
 	prometheus.MustRegister(metrics.lastSyncTimestamp)
 	prometheus.MustRegister(metrics.ingressesTotal)
 	prometheus.MustRegister(metrics.routegroupsTotal)
@@ -140,9 +144,7 @@ func registerMetrics() {
 	prometheus.MustRegister(metrics.certificatesTotal)
 	prometheus.MustRegister(metrics.cloudWatchAlarmsTotal)
 	prometheus.MustRegister(metrics.changesTotal)
-}
 
-func serveMetrics(address string) {
 	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(address, nil))
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -1454,6 +1454,8 @@ func TestBuildModel(t *testing.T) {
 		},
 	)
 
+	const certTTL = time.Hour
+
 	for _, test := range []struct {
 		title         string
 		certs         CertificatesFinder
@@ -1613,16 +1615,14 @@ func TestBuildModel(t *testing.T) {
 				maxCertsPerLB = test.maxCertsPerLB
 			}
 
-			w := &worker{
-				certTTL:      1 * time.Hour,
-				certsPerALB:  maxCertsPerLB,
-				globalWAFACL: test.globalWAFACL,
-			}
-			m := w.buildManagedModel(
+			m := buildManagedModel(
 				certs,
+				maxCertsPerLB,
+				certTTL,
 				test.ingresses,
 				test.stacks,
 				test.alarms,
+				test.globalWAFACL,
 			)
 
 			test.validate(t, m)

--- a/worker_test.go
+++ b/worker_test.go
@@ -476,7 +476,16 @@ func TestResourceConversionOneToOne(tt *testing.T) {
 			}
 
 			log.SetLevel(log.DebugLevel)
-			problems := doWork(ctx, scenario.certsProvider, 10, time.Hour, a, k, "")
+
+			w := &worker{
+				awsAdapter:    a,
+				kubeAdapter:   k,
+				metrics:       newMetrics(),
+				certsProvider: scenario.certsProvider,
+				certsPerALB:   10,
+				certTTL:       time.Hour,
+			}
+			problems := w.doWork(ctx)
 
 			if scenario.problems != nil {
 				assert.Len(t, problems.Errors(), len(scenario.problems))
@@ -1445,8 +1454,6 @@ func TestBuildModel(t *testing.T) {
 		},
 	)
 
-	const certTTL = time.Hour
-
 	for _, test := range []struct {
 		title         string
 		certs         CertificatesFinder
@@ -1606,14 +1613,16 @@ func TestBuildModel(t *testing.T) {
 				maxCertsPerLB = test.maxCertsPerLB
 			}
 
-			m := buildManagedModel(
+			w := &worker{
+				certTTL:      1 * time.Hour,
+				certsPerALB:  maxCertsPerLB,
+				globalWAFACL: test.globalWAFACL,
+			}
+			m := w.buildManagedModel(
 				certs,
-				maxCertsPerLB,
-				certTTL,
 				test.ingresses,
 				test.stacks,
 				test.alarms,
-				test.globalWAFACL,
 			)
 
 			test.validate(t, m)
@@ -1622,7 +1631,8 @@ func TestBuildModel(t *testing.T) {
 }
 
 func TestDoWorkPanicReturnsProblem(t *testing.T) {
-	problem := doWork(context.Background(), nil, 0, 0, nil, nil, "")
+	w := &worker{}
+	problem := w.doWork(context.Background())
 
 	require.NotNil(t, problem, "expected problem")
 	require.Len(t, problem.Errors(), 1)


### PR DESCRIPTION
Add worker struct to hold references to adapters, metrics and configuration values and convert functions into its methods to avoid using global variables and passing a lot of parameters around.

The only global variable still in use is `firstRun` ~hacked~ introduced by #258