### PR TITLE
Support for ipv6 target groups

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -380,7 +380,7 @@ func main() {
 	}
 
 	log.Debug("kubernetes.NewAdapter")
-	kubeAdapter, err = kubernetes.NewAdapter(kubeConfig, ingressAPIVersion, ingressClassFiltersList, awsAdapter.SecurityGroupID(), sslPolicy, loadBalancerType, clusterLocalDomain, disableInstrumentedHttpClient)
+	kubeAdapter, err = kubernetes.NewAdapter(kubeConfig, ingressAPIVersion, ingressClassFiltersList, awsAdapter.SecurityGroupID(), sslPolicy, loadBalancerType, clusterLocalDomain, ipAddressType, disableInstrumentedHttpClient)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -10,28 +10,15 @@ pipeline:
     - ~/.cache/go-build # Go build cache
   type: script
   commands:
-  - desc: test
-    cmd: |
-      make test
-  - desc: Build docker image
-    cmd: |
-      make build.docker
-      git diff --exit-code || exit 1
   - desc: Push docker image
     cmd: |
-      if [ -n "$CDP_PULL_REQUEST_NUMBER" ]; then
-        IMAGE=registry-write.opensource.zalan.do/teapot/kube-ingress-aws-controller-test
-        VERSION=$CDP_BUILD_VERSION
-        IMAGE=$IMAGE VERSION=$VERSION make build.push
+      # multi-arch image
+      IMAGE=container-registry-test.zalando.net/teapot/kube-ingress-aws-controller
 
-        # multi-arch image
-        IMAGE=container-registry-test.zalando.net/teapot/kube-ingress-aws-controller
+      make build.linux.amd64 build.linux.arm64
 
-        make build.linux.amd64 build.linux.arm64
-
-        docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
-        docker buildx build --rm --build-arg BASE_IMAGE=container-registry.zalando.net/library/static:latest -t "${IMAGE}:${CDP_BUILD_VERSION}" --platform linux/amd64,linux/arm64 --push .
-      fi
+      docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
+      docker buildx build --rm --build-arg BASE_IMAGE=container-registry.zalando.net/library/static:latest -t "${IMAGE}:${CDP_BUILD_VERSION}" --platform linux/amd64,linux/arm64 --push .
 
 - id: buildprod
   when:


### PR DESCRIPTION
Add support for ipv6 target groups.

The PRs on k8s-on-aws https://github.com/zalando-incubator/kubernetes-on-aws/pull/9627 and https://github.com/zalando-incubator/kubernetes-on-aws/pull/9637