### PR TITLE
packaging: add helm chart

### DIFF
--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -4,6 +4,10 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: read   # for actions/checkout
+  packages: write  # for pushing to GHCR (docker image + helm chart)
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: "${{ github.repository }}"

--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -66,3 +66,32 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  helm-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Extract chart version
+        id: chart-version
+        run: |
+          # Strip leading 'v' from the git tag (e.g. v0.20.1 -> 0.20.1)
+          echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        run: |
+          helm registry login ghcr.io \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package Helm chart
+        run: |
+          helm package helm/kube-ingress-aws-controller \
+            --version ${{ steps.chart-version.outputs.version }} \
+            --app-version ${{ github.ref_name }}
+
+      - name: Push Helm chart to GHCR
+        run: |
+          helm push kube-ingress-aws-controller-${{ steps.chart-version.outputs.version }}.tgz \
+            oci://ghcr.io/${{ github.repository_owner }}

--- a/helm/kube-ingress-aws-controller/Chart.yaml
+++ b/helm/kube-ingress-aws-controller/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: kube-ingress-aws-controller
+description: A Helm chart for the Kubernetes Ingress AWS Controller
+type: application
+version: 0.1.0
+appVersion: "v0.20"
+home: https://github.com/zalando-incubator/kube-ingress-aws-controller
+sources:
+  - https://github.com/zalando-incubator/kube-ingress-aws-controller
+keywords:
+  - ingress
+  - aws
+  - alb
+  - nlb
+maintainers:
+  - name: zalando-incubator

--- a/helm/kube-ingress-aws-controller/templates/NOTES.txt
+++ b/helm/kube-ingress-aws-controller/templates/NOTES.txt
@@ -1,0 +1,22 @@
+kube-ingress-aws-controller has been deployed.
+
+Controller: {{ include "kube-ingress-aws-controller.fullname" . }}
+Namespace:  {{ .Values.namespace }}
+Image:      {{ .Values.image.repository }}:{{ .Values.image.tag }}
+
+Configuration:
+  Load Balancer Type:  {{ .Values.controller.loadBalancerType }}
+  Target Access Mode:  {{ .Values.controller.targetAccessMode }}
+  SSL Policy:          {{ .Values.controller.sslPolicy }}
+  RouteGroups RBAC:    {{ .Values.rbac.routegroups.enabled }}
+  VPA:                 {{ .Values.vpa.enabled }}
+
+To attach an IAM role to the service account, set:
+
+  EKS IRSA:
+    serviceAccount.annotations."eks.amazonaws.com/role-arn"=arn:aws:iam::<account>:role/<role-name>
+
+  kiam / kube2iam:
+    serviceAccount.annotations."iam.amazonaws.com/role"=<role-name>
+
+Metrics are exposed on port 7979 at /metrics.

--- a/helm/kube-ingress-aws-controller/templates/_helpers.tpl
+++ b/helm/kube-ingress-aws-controller/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kube-ingress-aws-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kube-ingress-aws-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "kube-ingress-aws-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "kube-ingress-aws-controller.labels" -}}
+helm.sh/chart: {{ include "kube-ingress-aws-controller.chart" . }}
+{{ include "kube-ingress-aws-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "kube-ingress-aws-controller.selectorLabels" -}}
+application: {{ include "kube-ingress-aws-controller.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "kube-ingress-aws-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kube-ingress-aws-controller.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/kube-ingress-aws-controller/templates/clusterrole.yaml
+++ b/helm/kube-ingress-aws-controller/templates/clusterrole.yaml
@@ -1,0 +1,53 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kube-ingress-aws-controller.fullname" . }}
+  labels:
+    {{- include "kube-ingress-aws-controller.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+{{- if .Values.rbac.routegroups.enabled }}
+- apiGroups:
+  - zalando.org
+  resources:
+  - routegroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - zalando.org
+  resources:
+  - routegroups/status
+  verbs:
+  - patch
+  - update
+{{- end }}

--- a/helm/kube-ingress-aws-controller/templates/clusterrolebinding.yaml
+++ b/helm/kube-ingress-aws-controller/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kube-ingress-aws-controller.fullname" . }}
+  labels:
+    {{- include "kube-ingress-aws-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kube-ingress-aws-controller.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kube-ingress-aws-controller.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}

--- a/helm/kube-ingress-aws-controller/templates/deployment.yaml
+++ b/helm/kube-ingress-aws-controller/templates/deployment.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kube-ingress-aws-controller.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "kube-ingress-aws-controller.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kube-ingress-aws-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kube-ingress-aws-controller.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.metrics.podAnnotations.enabled .Values.podAnnotations }}
+      annotations:
+        {{- if .Values.metrics.podAnnotations.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: {{ .Values.metrics.path }}
+        prometheus.io/port: {{ .Values.metrics.port | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kube-ingress-aws-controller.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: controller
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --target-access-mode={{ .Values.controller.targetAccessMode }}
+            - --load-balancer-type={{ .Values.controller.loadBalancerType }}
+            - --ssl-policy={{ .Values.controller.sslPolicy }}
+            - --ip-addr-type={{ .Values.controller.ipAddrType }}
+            - --idle-connection-timeout={{ .Values.controller.idleConnectionTimeout }}
+            - --deregistration-delay-timeout={{ .Values.controller.deregistrationDelayTimeout }}
+            - --cert-polling-interval={{ .Values.controller.certPollingInterval }}
+            - --nlb-zone-affinity={{ .Values.controller.nlbZoneAffinity }}
+            {{- with .Values.controller.clusterLocalDomain }}
+            - --cluster-local-domain={{ . }}
+            {{- end }}
+            {{- if .Values.controller.stackTerminationProtection }}
+            - --stack-termination-protection
+            {{- end }}
+            {{- if .Values.controller.nlbCrossZone }}
+            - --nlb-cross-zone
+            {{- end }}
+            {{- if .Values.controller.nlbHttpEnabled }}
+            - --nlb-http-enabled
+            {{- end }}
+            {{- with .Values.controller.nlbHttpTargetPort }}
+            - --nlb-http-target-port={{ . }}
+            {{- end }}
+            {{- if .Values.controller.denyInternalDomains }}
+            - --deny-internal-domains
+            {{- end }}
+            {{- range $key, $value := .Values.controller.additionalStackTags }}
+            - --additional-stack-tags={{ $key }}={{ $value }}
+            {{- end }}
+            {{- with .Values.controller.certFilterTag }}
+            - --cert-filter-tag={{ . }}
+            {{- end }}
+            {{- with .Values.controller.clusterID }}
+            - --cluster-id={{ . }}
+            {{- end }}
+            {{- with .Values.controller.vpcID }}
+            - --vpc-id={{ . }}
+            {{- end }}
+          env:
+            {{- with .Values.aws.region }}
+            - name: AWS_REGION
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.aws.customFilters }}
+            - name: CUSTOM_FILTERS
+              value: {{ . | quote }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 7979
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/kube-ingress-aws-controller/templates/serviceaccount.yaml
+++ b/helm/kube-ingress-aws-controller/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kube-ingress-aws-controller.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "kube-ingress-aws-controller.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/kube-ingress-aws-controller/templates/vpa.yaml
+++ b/helm/kube-ingress-aws-controller/templates/vpa.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.vpa.enabled -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "kube-ingress-aws-controller.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "kube-ingress-aws-controller.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kube-ingress-aws-controller.fullname" . }}
+  updatePolicy:
+    updateMode: Recreate
+  resourcePolicy:
+    containerPolicies:
+    - containerName: controller
+      maxAllowed:
+        {{- toYaml .Values.vpa.maxAllowed | nindent 8 }}
+{{- end }}

--- a/helm/kube-ingress-aws-controller/values.yaml
+++ b/helm/kube-ingress-aws-controller/values.yaml
@@ -1,0 +1,170 @@
+# Default values for kube-ingress-aws-controller.
+# Defaults are sourced from the controller binary (aws/adapter.go, controller.go)
+# and the reference deployment in kubernetes-on-aws.
+
+replicaCount: 1
+
+# Namespace to deploy into. Override with --set namespace=<ns> if needed.
+namespace: kube-system
+
+image:
+  repository: ghcr.io/zalando-incubator/kube-ingress-aws-controller
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Service account configuration.
+# Set annotations to attach an IAM role:
+#   EKS IRSA:  eks.amazonaws.com/role-arn: "arn:aws:iam::<account>:role/<role-name>"
+#   kiam/kube2iam:  iam.amazonaws.com/role: "<role-name>"
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# RBAC configuration
+rbac:
+  # Enable routegroup (zalando.org/routegroups) permissions in the ClusterRole.
+  # Disable if your cluster does not have the RouteGroup CRD installed.
+  routegroups:
+    enabled: true
+
+# AWS-specific settings passed as environment variables
+aws:
+  # AWS region where the cluster is running. Required.
+  region: ""
+  # Custom EC2 instance filters used to discover worker nodes.
+  # Example: "tag:kubernetes.io/cluster/<cluster-name>=owned tag:node.kubernetes.io/role=worker"
+  customFilters: ""
+
+# Controller CLI flags.
+# Only flags that differ from binary defaults need to be set.
+# See: https://github.com/zalando-incubator/kube-ingress-aws-controller#options
+controller:
+  # Target access mode. Required. One of: HostPort, AWSCNI, Legacy.
+  # HostPort: target type 'instance', discovers EC2 instances via AWS API.
+  # AWSCNI:   target type 'ip', discovers pod IPs via Kubernetes API.
+  # Legacy:   same as HostPort but without explicit target type (backward compat).
+  targetAccessMode: HostPort
+
+  # Load balancer type: application (ALB) or network (NLB).
+  # Default: network (nlb_switch=exec in config-defaults.yaml)
+  loadBalancerType: network
+
+  # SSL policy for ALB HTTPS listeners.
+  # Default: ELBSecurityPolicy-TLS13-1-2-Res-2021-06
+  sslPolicy: "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+
+  # IP address type for the load balancer: ipv4 or dualstack.
+  # Default: ipv4
+  ipAddrType: ipv4
+
+  # Cluster-local domain. Hostnames matching this domain will not trigger LB creation.
+  # Default: cluster.local
+  clusterLocalDomain: "cluster.local"
+
+  # Enable CloudFormation stack termination protection.
+  # Default: true (matches reference deployment which always enables this)
+  stackTerminationProtection: true
+
+  # Idle connection timeout for ALBs (1s–4000s).
+  # Default: 1m
+  idleConnectionTimeout: "1m"
+
+  # Deregistration delay timeout for target groups (1s–3600s).
+  # Default: 10s (from config-defaults.yaml)
+  deregistrationDelayTimeout: "10s"
+
+  # Certificate polling interval.
+  # Default: 2m (from config-defaults.yaml)
+  certPollingInterval: "2m"
+
+  # NLB: enable cross-zone load balancing.
+  # Default: true (from config-defaults.yaml)
+  nlbCrossZone: true
+
+  # NLB: zone affinity (dns_record.client_routing_policy).
+  # Default: any_availability_zone
+  nlbZoneAffinity: "any_availability_zone"
+
+  # NLB: enable HTTP (port 80).
+  # Default: true (nlb_switch=exec in config-defaults.yaml)
+  nlbHttpEnabled: true
+
+  # NLB: target port for HTTP listener (requires nlbHttpEnabled: true).
+  # Default: 9998 (from reference deployment)
+  nlbHttpTargetPort: 9998
+
+  # Deny requests whose Host header matches an internal domain.
+  # Default: true (matches reference deployment which always enables this)
+  denyInternalDomains: true
+
+  # Additional CloudFormation stack tags as key/value pairs.
+  # Defaults match the reference deployment.
+  additionalStackTags:
+    InfrastructureComponent: "true"
+    application: kube-ingress-aws-controller
+
+  # Cert filter tag — only consider ACM/IAM certificates that have this tag set.
+  # Default: "kubernetes=enabled" (from config-defaults.yaml)
+  certFilterTag: "kubernetes=enabled"
+
+  # Optional: cluster ID. Auto-discovered from EC2 metadata if not set.
+  clusterID: ""
+
+  # Optional: VPC ID. Auto-discovered from EC2 metadata if not set.
+  vpcID: ""
+
+# Pod resource requests and limits.
+# Defaults match the zalando reference deployment.
+resources:
+  limits:
+    cpu: 50m
+    memory: 4Gi
+  requests:
+    cpu: 50m
+    memory: 4Gi
+
+# Metrics / Prometheus scraping configuration.
+metrics:
+  port: 7979
+  path: /metrics
+  # When enabled, adds prometheus.io/* annotations to the pod template so that
+  # Prometheus can auto-discover and scrape the controller. Set to false to
+  # suppress these annotations entirely.
+  podAnnotations:
+    enabled: true
+
+# Additional free-form pod annotations. Merged with any metrics annotations above.
+podAnnotations: {}
+
+# Pod labels (in addition to selector labels).
+podLabels: {}
+
+# Priority class for the controller pod.
+priorityClassName: ""
+
+# DNS config for the controller pod.
+dnsConfig:
+  options:
+    - name: ndots
+      value: "1"
+
+# Node selector for the controller pod.
+nodeSelector: {}
+
+# Tolerations for the controller pod.
+tolerations: []
+
+# Affinity rules for the controller pod.
+affinity: {}
+
+# VerticalPodAutoscaler configuration.
+vpa:
+  enabled: false
+  maxAllowed:
+    memory: 4Gi


### PR DESCRIPTION
To make skipper more open source friendly and has an easy way to replace nginx-ingress, we need to make it easy for new teams to plug and play.

With AI making coding cheap in some cases, this is a good use case to actually maintain the helm chart and use AI to support with it.

The helm chart was created with https://github.com/zalando-incubator/kubernetes-on-aws/blob/dev/cluster/manifests/ingress-controller in consideration

To make skipper as an ingress controller package, we need:

- [ ] Make a package from this repo and add as an optional dependency in skipper package
- [ ] Use coreDNS & externalDNS also as optional dependencies
- [ ] Make/update skipper helm package

Todo:

- [ ] Test package in local cluster
- [ ] Test package in AWS cluster
- [ ] Test package in other cloud providers