### PR TITLE
Remove references to registry.opensource.zalan.do

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3.13:latest
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12:latest
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY        ?= kube-ingress-aws-controller
 VERSION       ?= $(shell git describe --tags --always --dirty)
-IMAGE         ?= registry-write.opensource.zalan.do/teapot/$(BINARY)
+IMAGE         ?= ghcr.io/zalando-incubator/$(BINARY)
 TAG           ?= $(VERSION)
 SOURCES       = $(shell find . -name '*.go')
 DOCKERFILE    ?= Dockerfile

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -20,10 +20,6 @@ pipeline:
   - desc: Push docker image
     cmd: |
       if [ -n "$CDP_PULL_REQUEST_NUMBER" ]; then
-        IMAGE=registry-write.opensource.zalan.do/teapot/kube-ingress-aws-controller-test
-        VERSION=$CDP_BUILD_VERSION
-        IMAGE=$IMAGE VERSION=$VERSION make build.push
-
         # multi-arch image
         IMAGE=container-registry-test.zalando.net/teapot/kube-ingress-aws-controller
 
@@ -59,10 +55,8 @@ pipeline:
       echo "Creating release for tag: ${VERSION}"
       git gh-tag $VERSION
       echo "create and push docker container"
-      IMAGE=registry-write.opensource.zalan.do/teapot/kube-ingress-aws-controller
-      IMAGE=$IMAGE VERSION=$VERSION make build.docker
+      make
       git diff --stat --exit-code
-      IMAGE=$IMAGE VERSION=$VERSION make build.push
 
       # multi-arch image (Zalando private)
       VERSION=$VERSION make build.linux.amd64 build.linux.arm64
@@ -76,9 +70,9 @@ pipeline:
       echo -e "### Changes\n" >$tf
       git log -1 --pretty=%B | grep -v -F 'Signed-off-by:' | grep -v -F 'Co-authored-by:' >>$tf
       echo -e "\n### Docker image\n" >>$tf
-      echo -e "Docker image is available in Zalando's Open Source registry:\n" >>$tf
+      echo -e "Docker image is available in Github Container Registry:\n" >>$tf
       echo -e '```' >>$tf
-      echo -e "docker run -it registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:${VERSION} --help" >>$tf
+      echo -e "docker run -it ghcr.io/zalando-incubator/kube-ingress-aws-controller:${VERSION} --help" >>$tf
       echo -e '```' >>$tf
       echo "################################"
       cat $tf

--- a/deploy/examples/sample-app-v1.yaml
+++ b/deploy/examples/sample-app-v1.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: skipper-demo
-        image: registry.opensource.zalan.do/pathfinder/skipper:latest
+        image: ghcr.io/zalando/skipper:latest
         args:
           - "skipper"
           - "-inline-routes"

--- a/deploy/examples/sample-app-v2.yaml
+++ b/deploy/examples/sample-app-v2.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: skipper-demo
-        image: registry.opensource.zalan.do/pathfinder/skipper:latest
+        image: ghcr.io/zalando/skipper:latest
         args:
           - "skipper"
           - "-inline-routes"

--- a/deploy/skipper.AWSCNI.yaml.example
+++ b/deploy/skipper.AWSCNI.yaml.example
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: skipper-ingress
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:latest
+        image: ghcr.io/zalando/skipper:latest
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -80,7 +80,7 @@ spec:
       serviceAccountName: kube-ingress-aws
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:latest
+        image: ghcr.io/zalando-incubator/kube-ingress-aws-controller:latest
         env:
         - name: AWS_REGION
           value: <REGION>

--- a/deploy/skipper.yaml.example
+++ b/deploy/skipper.yaml.example
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: skipper-ingress
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:latest
+        image: ghcr.io/zalando/skipper:latest
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
Zalando wants to decommission the docker registry hosting images on `registry.opensource.zalan.do`

This removes any reference to `registry.opensource.zalan.do` and replaces with open source images where applicable.

We will provide public images via ghcr.io. A github action is added to build and push those images.